### PR TITLE
Bug fix for chat app

### DIFF
--- a/bin/service_chat.py
+++ b/bin/service_chat.py
@@ -14,7 +14,8 @@ def generate_script(config):
     print(config["HOST"],config["PORT"])
     with open("./interfaces/chat_app/static/script.js-template","r") as f:
         data = f.read()
-    data = data.replace('XX-HTTP_HOSTNAME-XX',str(config["HOSTNAME"]))
+    #data = data.replace('XX-HTTP_HOSTNAME-XX',str(config["HOSTNAME"]))
+    data = data.replace('XX-HTTP_HOSTNAME-XX',str("127.0.0.1"))
     data = data.replace('XX-HTTP_PORT-XX',str(config["PORT"]))
     with open("./interfaces/chat_app/static/script.js","w") as f:
         f.write(data)

--- a/bin/service_chat.py
+++ b/bin/service_chat.py
@@ -14,8 +14,6 @@ def generate_script(config):
     print(config["HOST"],config["PORT"])
     with open("./interfaces/chat_app/static/script.js-template","r") as f:
         data = f.read()
-    #data = data.replace('XX-HTTP_HOSTNAME-XX',str(config["HOSTNAME"]))
-    data = data.replace('XX-HTTP_HOSTNAME-XX',str("127.0.0.1"))
     data = data.replace('XX-HTTP_PORT-XX',str(config["PORT"]))
     with open("./interfaces/chat_app/static/script.js","w") as f:
         f.write(data)

--- a/interfaces/chat_app/app.py
+++ b/interfaces/chat_app/app.py
@@ -58,7 +58,7 @@ class ChatWrapper:
             print(" INFO - json_file found.")
         except FileNotFoundError:
             data = {}  # if the file doesn't exist or is empty, initialize an empty dictionary
-            print(" ERROR - json_file not found.")
+            print(" ERROR - json_file not found. Creating a new one")
 
         discussion_id = str(discussion_id)
         # check if the discussion ID exists in the JSON data

--- a/interfaces/chat_app/static/script.js
+++ b/interfaces/chat_app/static/script.js
@@ -40,7 +40,7 @@ const refreshChat = async () => {
 }
 
 const getChatResponse = async (incomingChatDiv) => {
-    const API_URL = "http://ppc.mit.edu:7681/get_chat_response";
+    const API_URL = "http://127.0.0.1:7681/get_chat_response";
     const pElement = document.createElement("div");
 
      // Define the properties and data for the API request

--- a/interfaces/chat_app/static/script.js-template
+++ b/interfaces/chat_app/static/script.js-template
@@ -40,7 +40,7 @@ const refreshChat = async () => {
 }
 
 const getChatResponse = async (incomingChatDiv) => {
-    const API_URL = "http://XX-HTTP_HOSTNAME-XX:XX-HTTP_PORT-XX/get_chat_response";
+    const API_URL = "http://127.0.0.1:XX-HTTP_PORT-XX/get_chat_response";
     const pElement = document.createElement("div");
 
      // Define the properties and data for the API request


### PR DESCRIPTION
The back end of the chat app works by calling a rest API in order to call the python function. The API call is routed through the sub-link "portnumber:get_chat_response/". However, this link is not exposed to external ports. Therefore, when you need to acsess it, it needs to be through an internal port.