### PR TITLE
Patch/mailbox authentication

### DIFF
--- a/A2rchi/bin/service_mailbox.py
+++ b/A2rchi/bin/service_mailbox.py
@@ -10,12 +10,15 @@ import time
 # set openai
 os.environ['OPENAI_API_KEY'] = read_secret("OPENAI_API_KEY")
 os.environ['HUGGING_FACE_HUB_TOKEN'] = read_secret("HUGGING_FACE_HUB_TOKEN")
+user = read_secret('IMAP_USER')
+password = read_secret('IMAP_PW')
+
 print("Starting Mailbox Service")
 
 config = Config_Loader().config["utils"]
 cleo = cleo.Cleo('Cleo_Helpdesk')
 
 while True:
-    mail = mailbox.Mailbox()
+    mail = mailbox.Mailbox(user = user, password = password)
     mail.process_messages(cleo)
     time.sleep(int(config["mailbox"]["mailbox_update_time"]))

--- a/A2rchi/utils/mailbox.py
+++ b/A2rchi/utils/mailbox.py
@@ -15,13 +15,13 @@ ISSUE_ID_OFFSET = 9
 class Mailbox:
     'A class to describe the mailbox usage.'
 
-    def __init__(self):
+    def __init__(self, user, password):
         """
         The mailbox (should be a singleton).
         """
         self.mailbox = None
-        self.user = read_secret('IMAP_USER')
-        self.password = read_secret('IMAP_PW')
+        self.user = user
+        self.password = password
         self.config = Config_Loader().config["utils"]["mailbox"]
 
         # make sure to open the mailbox


### PR DESCRIPTION
Before, we needed to read the secret every time the mailbox got initialized, which doesn’t work if the secret is removed. Now, the secret username/password is saved at the very beginning of starting the mailbox service as a python variable.