### PR TITLE
Feature/generalize prompts

### DIFF
--- a/A2rchi/chains/prompts.py
+++ b/A2rchi/chains/prompts.py
@@ -4,8 +4,8 @@ from A2rchi.utils.config_loader import Config_Loader
 
 config = Config_Loader().config["chains"]["prompts"]
 
-def read_prompt(prompt_name, is_condense_prompt=False, is_main_prompt=False):
-    with open(f"config/prompts/{prompt_name}", "r") as f:
+def read_prompt(prompt_filepath, is_condense_prompt=False, is_main_prompt=False):
+    with open(prompt_filepath, "r") as f:
         raw_prompt = f.read()
 
     prompt = ""

--- a/A2rchi/chains/prompts.py
+++ b/A2rchi/chains/prompts.py
@@ -1,27 +1,31 @@
 # flake8: noqa
 from langchain.prompts.prompt import PromptTemplate
+from A2rchi.utils.config_loader import Config_Loader
 
-condense_history_template = """Given the following conversation between you (the AI named A2rchi), a human user who needs help, and an expert, and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
+config = Config_Loader().config["chains"]["prompts"]
 
-Chat History:
-{chat_history}
-Follow Up Input: {question}
-Standalone question:"""
+def read_prompt(prompt_name, is_condense_prompt=False, is_main_prompt=False):
+    with open(f"config/prompts/{prompt_name}", "r") as f:
+        raw_prompt = f.read()
 
-prompt_template = """You are a conversational chatbot named A2rchi who helps people navigate a computing resource named subMIT. You will be provided context to help you answer their questions. 
-Using your linux and computing knowledge, answer the question at the end. Unless otherwise indicated, assume the users are not well versed computing.
- Please do not assume that subMIT machines have anything installed on top of native linux except if the context mentions it.
-If you don't know, say "I don't know", if you need to ask a follow up question, please do.
+    prompt = ""
+    for line in raw_prompt.split("\n"):
+        if len(line.lstrip())>0 and line.lstrip()[0:1] != "#":
+            prompt += line + "\n"
 
-Context: {context} Additionally, it is always preferred to use conda, if possible.
+    if is_condense_prompt and ("{chat_history}" not in prompt or "{question}" not in prompt):
+        raise ValueError("""Condensing prompt must contain \"{chat_history}\" and \"{question}\" tags. Instead, found prompt to be:
+                         """ + prompt)
+    if is_main_prompt and ("{context}" not in prompt or "{question}" not in prompt):
+        raise ValueError("""Condensing prompt must contain \"{context}\" and \"{question}\" tags. Instead, found prompt to be:
+                         """ + prompt)
 
-Question: {question}
-Helpful Answer:"""
+    return prompt
 
 QA_PROMPT = PromptTemplate(
-    template=prompt_template, input_variables=["context", "question"]
+    template=read_prompt(config["MAIN_PROMPT"], is_main_prompt=True), input_variables=["context", "question"]
 )
 
 CONDENSE_QUESTION_PROMPT = PromptTemplate(
-    template=condense_history_template, input_variables=["chat_history", "question"]
+    template=read_prompt(config["CONDENSING_PROMPT"], is_condense_prompt=True), input_variables=["chat_history", "question"]
 )

--- a/A2rchi/utils/scraper.py
+++ b/A2rchi/utils/scraper.py
@@ -59,7 +59,7 @@ class Scraper():
                 data = f.read()
 
             for line in data.split("\n"):
-                if len(line) > 0 and line[0] != '#':
+                if len(line.lstrip())>0 and line.lstrip()[0:1] != "#":
                     urls.append(line)
 
         return urls

--- a/config/dev-config.yaml
+++ b/config/dev-config.yaml
@@ -32,6 +32,9 @@ chains:
       - User
       - A2rchi
       - Expert 
+  prompts:
+    CONDENSING_PROMPT: condense.prompt #name of the prompt (in config/prompts) that serves to condense a history and a question into a single question
+    MAIN_PROMPT: submit.prompt #name of the main prompt (in config/prompts) which takes in a single question and a context.
   chain: 
     # pick one of the models listed in the model class map below
     MODEL_NAME: OpenAILLM # LlamaLLM

--- a/config/dev-config.yaml
+++ b/config/dev-config.yaml
@@ -33,8 +33,10 @@ chains:
       - A2rchi
       - Expert 
   prompts:
-    CONDENSING_PROMPT: condense.prompt #name of the prompt (in config/prompts) that serves to condense a history and a question into a single question
-    MAIN_PROMPT: submit.prompt #name of the main prompt (in config/prompts) which takes in a single question and a context.
+    # prompt that serves to condense a history and a question into a single question
+    CONDENSING_PROMPT: config/prompts/condense.prompt
+    # main prompt which takes in a single question and a context.
+    MAIN_PROMPT: config/prompts/submit.prompt
   chain: 
     # pick one of the models listed in the model class map below
     MODEL_NAME: OpenAILLM # LlamaLLM

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -32,6 +32,9 @@ chains:
       - User
       - A2rchi
       - Expert 
+  prompts:
+    CONDENSING_PROMPT: condense.prompt #name of the prompt (in config/prompts) that serves to condense a history and a question into a single question
+    MAIN_PROMPT: submit.prompt #name of the main prompt (in config/prompts) which takes in a single question and a context.
   chain: 
     # pick one of the models listed in the model class map below
     MODEL_NAME: OpenAILLM 

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -33,8 +33,10 @@ chains:
       - A2rchi
       - Expert 
   prompts:
-    CONDENSING_PROMPT: condense.prompt #name of the prompt (in config/prompts) that serves to condense a history and a question into a single question
-    MAIN_PROMPT: submit.prompt #name of the main prompt (in config/prompts) which takes in a single question and a context.
+    # prompt that serves to condense a history and a question into a single question
+    CONDENSING_PROMPT: config/prompts/condense.prompt
+    # main prompt which takes in a single question and a context.
+    MAIN_PROMPT: config/prompts/submit.prompt
   chain: 
     # pick one of the models listed in the model class map below
     MODEL_NAME: OpenAILLM 

--- a/config/prompts/801.prompt
+++ b/config/prompts/801.prompt
@@ -1,0 +1,16 @@
+# Prompt used to qurery LLM with appropriate context and question.
+# This prompt is specific to 8.01 taught at MIT and likely will not perform well for other applications, where it is recommeneded to write your own prompt and change it in the config
+# 
+# All final promptsd must have the following tags in them, which will be filled with the appropriate information:
+#      {question}
+#      {context}
+#
+You are a conversational chatbot and teaching assisitant named A2rchi who helps students taking Classical Mechanics 1 at MIT (also called 8.01). You will be provided context to help you answer their questions. 
+Using your physics, math, and problem solving knowledge, answer the question at the end. Unless otherwise indicated, assume the users know high school level physics.
+Since you are a teaching assisitant, please try to give throughou answers to questions with explanations, instead of just giving the answer.
+If you don't know, say "I don't know". It is extremely important you only give correct answers. If you need to ask a follow up question, please do.
+
+Context: {context} 
+
+Question: {question}
+Helpful Answer:

--- a/config/prompts/condense.prompt
+++ b/config/prompts/condense.prompt
@@ -1,0 +1,13 @@
+# Prompt used to condense a chat history and a follow up question into a stand alone question. 
+# This is a very general prompt for condensing histories, so for base installs it will not need to be modified
+# 
+# All condensing prompts must have the following tags in them, which will be filled with the appropriate information:
+#      {chat_history}
+#      {question}
+#
+Given the following conversation between you (the AI named A2rchi), a human user who needs help, and an expert, and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
+
+Chat History:
+{chat_history}
+Follow Up Input: {question}
+Standalone question:

--- a/config/prompts/submit.prompt
+++ b/config/prompts/submit.prompt
@@ -1,0 +1,16 @@
+# Prompt used to qurery LLM with appropriate context and question.
+# This prompt is specific to subMIT and likely will not perform well for other applications, where it is recommeneded to write your own prompt and change it in the config
+# 
+# All final promptsd must have the following tags in them, which will be filled with the appropriate information:
+#      {question}
+#      {context}
+#
+You are a conversational chatbot named A2rchi who helps people navigate a computing resource named subMIT. You will be provided context to help you answer their questions. 
+Using your linux and computing knowledge, answer the question at the end. Unless otherwise indicated, assume the users are not well versed computing.
+ Please do not assume that subMIT machines have anything installed on top of native linux except if the context mentions it.
+If you don't know, say "I don't know", if you need to ask a follow up question, please do.
+
+Context: {context} Additionally, it is always preferred to use conda, if possible.
+
+Question: {question}
+Helpful Answer:


### PR DESCRIPTION
Create ability to specify prompts in the config. This allows A2rchi to be flexible across different applications. 

Additionally, fixed a small bug in commenting logic I noticed in `utils/scraper.py` (the previous code only recognized comments if the "#" was at the very beginning of the line)