### PR TITLE
moved api call from url /get_chat_response to /api/get_chat_response

### DIFF
--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -153,7 +153,7 @@ class FlaskAppWrapper(object):
         CORS(self.app)
 
         # add endpoints for flask app
-        self.add_endpoint('/get_chat_response', 'get_chat_response', self.get_chat_response, methods=["POST"])
+        self.add_endpoint('/api/get_chat_response', 'get_chat_response', self.get_chat_response, methods=["POST"])
         self.add_endpoint('/', '', self.index)
         self.add_endpoint('/terms', 'terms', self.terms)
 

--- a/A2rchi/interfaces/chat_app/static/script.js
+++ b/A2rchi/interfaces/chat_app/static/script.js
@@ -42,7 +42,7 @@ const refreshChat = async () => {
 }
 
 const getChatResponse = async (incomingChatDiv) => {
-    const API_URL = "http://0.0.0.0:7861/get_chat_response";
+    const API_URL = "http://0.0.0.0:7861/api/get_chat_response";
     const pElement = document.createElement("div");
 
      // Define the properties and data for the API request

--- a/A2rchi/interfaces/chat_app/static/script.js-template
+++ b/A2rchi/interfaces/chat_app/static/script.js-template
@@ -42,7 +42,7 @@ const refreshChat = async () => {
 }
 
 const getChatResponse = async (incomingChatDiv) => {
-    const API_URL = "http://0.0.0.0:XX-HTTP_PORT-XX/get_chat_response";
+    const API_URL = "http://0.0.0.0:XX-HTTP_PORT-XX/api/get_chat_response";
     const pElement = document.createElement("div");
 
      // Define the properties and data for the API request


### PR DESCRIPTION
Simple change, just to keep things clean we should start using the convention that all API calls occur to /api/*

Since we only explicitly do this once, we just have one commit that fixes it.