### PR TITLE
Bug/chunk id clash

### DIFF
--- a/A2rchi/utils/data_manager.py
+++ b/A2rchi/utils/data_manager.py
@@ -215,13 +215,16 @@ class DataManager():
                 metadata["filename"] = filename
             
             # create unique id for each chunk
-            # the first 12 bits of the id being the filename and the other 6 based on the chunk itself
+            # the first 12 bits of the id being the filename, 6 more based on the chunk itself, and the last 6 hashing the time
             ids = []
             for chunk in chunks:
                 identifier = hashlib.md5()
                 identifier.update(chunk.encode('utf-8'))
                 chunk_hash = str(int(identifier.hexdigest(),16))[0:6]
-                ids.append(str(filehash) + str(chunk_hash))
+                time_identifier = hashlib.md5()
+                time_identifier.update(str(time.time()).encode('utf-8'))
+                time_hash = str(int(identifier.hexdigest(),16))[0:6]
+                ids.append(str(filehash) + str(chunk_hash) + str(time_hash))
 
             print("Ids: ",ids)
             collection.add(embeddings=embeddings, ids=ids, documents=chunks, metadatas=metadatas)

--- a/A2rchi/utils/data_manager.py
+++ b/A2rchi/utils/data_manager.py
@@ -11,6 +11,7 @@ import chromadb
 import hashlib
 import os
 import yaml
+import time
 
 
 class DataManager():


### PR DESCRIPTION
Solves a bug where there are clashes between id's of chunks which are to be added to the vectorstore. 

Originally, it was thought that the hash is strong enough and long enough that there would be no conflicts. However, if there is some repeated text in the passage, it is very likely that the chunker will make two very similar chunks (if not identical) and these will cause a clash. We can later discuss if we want to do something different in this case, but for now it is halting deployment of 8.01 and we need a fix. Therefore, I added another 6 bits to hash the time step (which is truly unique).

Solves the below error in 8.01 prod:

```Ids:  ['Exam1_Practice_p2134299', 'Exam1_Practice_p2322552', 'Exam1_Practice_p2270054', 'Exam1_Practice_p2114515', 'Exam1_Practice_p2183468', 'Exam1_Practice_p2265078', 'Exam1_Practice_p2315635', 'Exam1_Practice_p2114515', 'Exam1_Practice_p2262479', 'Exam1_Practice_p2230324']
Exception in thread Thread-1 (run_data_manager):
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/root/A2rchi/A2rchi/bin/service_data_manager.py", line 52, in run_data_manager
    data_manager.update_vectorstore()
  File "/usr/local/lib/python3.10/site-packages/A2rchi/utils/data_manager.py", line 146, in update_vectorstore
    collection = self._add_to_vectorstore(collection, files_to_add, sources)
  File "/usr/local/lib/python3.10/site-packages/A2rchi/utils/data_manager.py", line 227, in _add_to_vectorstore
    collection.add(embeddings=embeddings, ids=ids, documents=chunks, metadatas=metadatas)
  File "/usr/local/lib/python3.10/site-packages/chromadb/api/models/Collection.py", line 95, in add
    ids, embeddings, metadatas, documents = self._validate_embedding_set(
  File "/usr/local/lib/python3.10/site-packages/chromadb/api/models/Collection.py", line 346, in _validate_embedding_set
    ids = validate_ids(maybe_cast_one_to_many(ids))
  File "/usr/local/lib/python3.10/site-packages/chromadb/api/types.py", line 140, in validate_ids
    raise errors.DuplicateIDError(message)
chromadb.errors.DuplicateIDError: Expected IDs to be unique, found duplicates of: Exam1_Practice_p2114515```