### PR TITLE
HotFix to Address Issue #104

### DIFF
--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -212,6 +212,7 @@ class FlaskAppWrapper(object):
         return render_template('terms.html')
     
     def like(self):
+        self.chat.lock.acquire()
         try:
             # Get the JSON data from the request body
             data = request.json
@@ -231,11 +232,16 @@ class FlaskAppWrapper(object):
             response = {'message': 'Liked', 'content': chat_content}
             return jsonify(response), 200
 
-
         except Exception as e:
             return jsonify({'error': str(e)}), 500
-        
+
+        # According to the Python documentation: https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
+        # this will still execute, before the function returns in the try or except block.
+        finally:
+            self.chat.lock.release()
+
     def dislike(self):
+        self.chat.lock.acquire()
         try:
             # Get the JSON data from the request body
             data = request.json
@@ -263,6 +269,10 @@ class FlaskAppWrapper(object):
             response = {'message': 'Disliked', 'content': chat_content}
             return jsonify(response), 200
 
-
         except Exception as e:
             return jsonify({'error': str(e)}), 500
+
+        # According to the Python documentation: https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
+        # this will still execute, before the function returns in the try or except block.
+        finally:
+            self.chat.lock.release()


### PR DESCRIPTION
Please see issue #104 for bug description.

### RCA
I believe the cause of this bug is that the `like` and `dislike` methods of our feedback endpoints do not acquire the `ChatWrapper` lock before writing to the `conversations_test.json` file. This can lead to a race condition where any (two or more) user(s) who submit a conversation and provide feedback simultaneously may cause some inconsistent state in our json file.

### Proposed Fix
We acquire the chat wrapper's lock before writing `like` and `dislike` feedback. We take care to release the lock in the `finally` branch of a `try-except`.