### PR TITLE
Fix/conversation loggin fix

### DIFF
--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/conversation_loggin_fix
 jobs:
   deploy-dev-system:
     runs-on: ubuntu-latest

--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -74,7 +74,7 @@ class ChatWrapper:
         discussion_dict = data.get(str(discussion_id), {})
 
         discussion_dict["meta"] = discussion_dict.get("meta", {})
-        if str(discussion_id) not in discussion_dict.keys(): #first time in discusssion
+        if str(discussion_id) not in data.keys(): #first time in discusssion
             discussion_dict["meta"]["time_first_used"] = time.time()
         discussion_dict["meta"]["time_last_used"] = time.time()
 


### PR DESCRIPTION
Two small fixes I missed in the logging implementation the first time around:

1. There is now a `meta` section in each discussion for logging. This includes a `time_last_used` which is when the discussion was last used .
2. Initially, the last response from a2rchi was not logged. This is fixed now. 

Tested to see if it was working in action #141