### PR TITLE
moving back to port 7683

### DIFF
--- a/config/prod-801-config.yaml
+++ b/config/prod-801-config.yaml
@@ -11,7 +11,7 @@ global:
 interfaces:
   chat_app:
     PORT: 7861
-    EXTERNAL_PORT: 7684
+    EXTERNAL_PORT: 7683
     HOST: "0.0.0.0" # either "0.0.0.0" (for public) or "127.0.0.1" (for internal)
     HOSTNAME: "t3desk019.mit.edu"  # careful, this is used for the chat service
     template_folder: "/root/A2rchi/A2rchi/interfaces/chat_app/templates"

--- a/deploy/prod-801/prod-801-compose.yaml
+++ b/deploy/prod-801/prod-801-compose.yaml
@@ -20,7 +20,7 @@ services:
       options:
         max-size: 10m
     ports:
-      - 7684:7861  # host:container
+      - 7683:7861  # host:container
     restart: always
 
   data-manager-prod-801:


### PR DESCRIPTION
Cleanup on 8.01 release after load spike. Takes care of step 2 in issue #125. Moves port back to 7683.