### PR TITLE
Feature/add timeout to client requests

### DIFF
--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/add-timeout-to-client-requests
 jobs:
   deploy-dev-system:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/add-timeout-to-client-requests
 jobs:
   deploy-dev-system:
     runs-on: ubuntu-latest

--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -363,6 +363,12 @@ class FlaskAppWrapper(object):
             A json with a response (html formatted plain text string) and a
             discussion ID (either None or an integer)
         """
+        # TODO: remove; only here to debug timeout
+        import time
+        time.sleep(130)
+
+        # TODO: also need to add timeout to server
+
         # compute timestamp at which message was received by server
         msg_ts = datetime.now()
 

--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -368,10 +368,6 @@ class FlaskAppWrapper(object):
             A json with a response (html formatted plain text string) and a
             discussion ID (either None or an integer)
         """
-        # TODO: remove; only here to debug timeout
-        import time
-        time.sleep(130)
-
         # compute timestamp at which message was received by server
         msg_ts = datetime.now()
 

--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -380,7 +380,7 @@ class FlaskAppWrapper(object):
         conversation_id = request.json.get('conversation_id')
         is_refresh = request.json.get('is_refresh')
         client_msg_ts = request.json.get('client_msg_ts') / 1000
-        client_timeout = request.json.get('timeout') / 1000
+        client_timeout = request.json.get('client_timeout') / 1000
 
         # query the chat and return the results.
         print(" INFO - Calling the ChatWrapper()")

--- a/A2rchi/interfaces/chat_app/app.py
+++ b/A2rchi/interfaces/chat_app/app.py
@@ -367,8 +367,6 @@ class FlaskAppWrapper(object):
         import time
         time.sleep(130)
 
-        # TODO: also need to add timeout to server
-
         # compute timestamp at which message was received by server
         msg_ts = datetime.now()
 
@@ -376,6 +374,13 @@ class FlaskAppWrapper(object):
         message = request.json.get('last_message')
         conversation_id = request.json.get('conversation_id')
         is_refresh = request.json.get('is_refresh')
+        client_msg_ts = request.json.get('client_msg_ts') / 1000
+        client_timeout = request.json.get('timeout') / 1000
+
+        # if timestamp from message is more than TIMEOUT_SECS in the past;
+        # do not generate response as the client will have timed out
+        if msg_ts - client_msg_ts > client_timeout:
+            return jsonify({'error': 'client timeout'}), 408
 
         # query the chat and return the results.
         print(" INFO - Calling the ChatWrapper()")

--- a/A2rchi/interfaces/chat_app/static/script.js-template
+++ b/A2rchi/interfaces/chat_app/static/script.js-template
@@ -100,8 +100,9 @@ const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
             last_message: conversation.slice(-1),
             conversation_id: conversation_id,
             is_refresh: isRefresh,
+            client_msg_ts: Date.now(),
+            client_timeout: DEFAULT_TIMEOUT_SECS * 1000
         }),
-        client_msg_ts: Date.now(),
         timeout: DEFAULT_TIMEOUT_SECS * 1000
     }
 
@@ -116,7 +117,7 @@ const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
         last_response_is_feedback_request = false;
     } catch (error) {
         pElement.classList.add("error");
-        pElement.textContent = "<p>Oops! Something went wrong while retrieving the response. Please try again.</p>";
+        pElement.textContent = "Oops! Something went wrong while retrieving the response. Please try again.";
     }
 
     // Remove the typing animation, append the paragraph element and save the chats to local storage

--- a/A2rchi/interfaces/chat_app/static/script.js-template
+++ b/A2rchi/interfaces/chat_app/static/script.js-template
@@ -101,6 +101,7 @@ const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
             conversation_id: conversation_id,
             is_refresh: isRefresh,
         }),
+        client_msg_ts: Date.now(),
         timeout: DEFAULT_TIMEOUT_SECS * 1000
     }
 
@@ -115,7 +116,7 @@ const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
         last_response_is_feedback_request = false;
     } catch (error) {
         pElement.classList.add("error");
-        pElement.textContent = "Oops! Something went wrong while retrieving the response. Please try again.";
+        pElement.textContent = "<p>Oops! Something went wrong while retrieving the response. Please try again.</p>";
     }
 
     // Remove the typing animation, append the paragraph element and save the chats to local storage

--- a/A2rchi/interfaces/chat_app/static/script.js-template
+++ b/A2rchi/interfaces/chat_app/static/script.js-template
@@ -13,11 +13,31 @@ const helpful_checkbox = document.getElementById("helpful_checkbox");
 const appropriate_checkbox = document.getElementById("appropriate_checkbox");
 popupForm.style.display = "none";
 
+// DEFINITIONS
+let DEFAULT_TIMEOUT_SECS = 120
 let userText = null;
 let conversation_id = null;
 let conversation = []
 let num_responses_since_last_rating = 0;
 let last_response_is_feedback_request = false;
+
+
+async function fetchWithTimeout(resource, options = {}) {
+    // extracts `timeout` field from options dict;
+    // will default to DEFAULT_TIMEOUT_SECS if no field is present
+    const { timeout = DEFAULT_TIMEOUT_SECS * 1000 } = options;
+
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+
+    const response = await fetch(resource, {
+      ...options,
+      signal: controller.signal
+    });
+    clearTimeout(id);
+
+    return response;
+}
 
 const loadDataFromLocalstorage = () => {
     // Load saved chats and theme from local storage and apply/add on the page
@@ -80,12 +100,13 @@ const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
             last_message: conversation.slice(-1),
             conversation_id: conversation_id,
             is_refresh: isRefresh,
-        })
+        }),
+        timeout: DEFAULT_TIMEOUT_SECS * 1000
     }
 
     // Send POST request to Flask API, get response and set the response as paragraph element text
     try {
-        const response = await (await fetch(API_URL, requestOptions)).json();
+        const response = await (await fetchWithTimeout(API_URL, requestOptions)).json();
         pElement.innerHTML = response.response;
         pElement.setAttribute('id', response.a2rchi_msg_id.toString());
         pElement.classList.add(".default-text");

--- a/A2rchi/interfaces/chat_app/static/script.js-template
+++ b/A2rchi/interfaces/chat_app/static/script.js-template
@@ -156,16 +156,20 @@ const likeResponse = (likeBtn) => {
     const API_URL = "http://XX-HOSTNAME-XX:XX-HTTP_PORT-XX/api/like";
 
      // Send an API request with the chat content and discussion ID
-     fetch(API_URL, {
-        method: "POST", // You may need to adjust the HTTP method
-        headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
-        },
-        body: JSON.stringify({
-            message_id: likeBtn.parentElement.previousElementSibling.querySelector("p").parentElement.id,
-        }),
-    })
+     try {
+        fetch(API_URL, {
+            method: "POST", // You may need to adjust the HTTP method
+            headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+            },
+            body: JSON.stringify({
+                message_id: likeBtn.parentElement.previousElementSibling.querySelector("p").parentElement.id,
+            }),
+        })
+     } catch (error) {
+        console.log("liked error message")
+     }
 }
 
 const dislikeResponse = (dislikeBtn) => {
@@ -188,22 +192,26 @@ const dislikeResponse = (dislikeBtn) => {
     function handleSubmitToAPI() {
         const additionalThoughts = additionalThoughtsInput.value;
 
-        fetch(API_URL, {
-            method: "POST", // You may need to adjust the HTTP method
-            headers: {
-                "Content-Type": "application/json",
-                "Access-Control-Allow-Origin": "*",
-            },
-            body: JSON.stringify({ 
-                message_id: dislikeBtn.parentElement.previousElementSibling.querySelector("p").parentElement.id,
-                feedback_msg: additionalThoughts,
-                incorrect: correct_checkbox.checked,
-                unhelpful: helpful_checkbox.checked,
-                inappropriate: appropriate_checkbox.checked,
-            }),
-        });
+        try {
+            fetch(API_URL, {
+                method: "POST", // You may need to adjust the HTTP method
+                headers: {
+                    "Content-Type": "application/json",
+                    "Access-Control-Allow-Origin": "*",
+                },
+                body: JSON.stringify({ 
+                    message_id: dislikeBtn.parentElement.previousElementSibling.querySelector("p").parentElement.id,
+                    feedback_msg: additionalThoughts,
+                    incorrect: correct_checkbox.checked,
+                    unhelpful: helpful_checkbox.checked,
+                    inappropriate: appropriate_checkbox.checked,
+                }),
+            });
+        } catch (error) {
+            console.log("disliked error message")
+        }
 
-        //hide pop up formi
+        //hide pop up form
         popupForm.style.display = "none";
     }
 

--- a/A2rchi/interfaces/chat_app/static/style.css
+++ b/A2rchi/interfaces/chat_app/static/style.css
@@ -170,7 +170,6 @@ span.material-symbols-rounded {
 }
 .chat .chat-details .error {
   padding: 0 50px 0 25px;
-  color: var(--text-color);
 }
 .chat .typing-animation {
   padding-left: 25px;

--- a/A2rchi/interfaces/chat_app/static/style.css
+++ b/A2rchi/interfaces/chat_app/static/style.css
@@ -168,6 +168,10 @@ span.material-symbols-rounded {
 .chat .chat-details p.error {
   color: #e55865;
 }
+.chat .chat-details .error {
+  padding: 0 50px 0 25px;
+  color: var(--text-color);
+}
 .chat .typing-animation {
   padding-left: 25px;
   display: inline-flex;


### PR DESCRIPTION
This feature adds timeout functionality to the client and server-sides of our chat application. On the client side we timeout the request after a specified duration (default 120s). Once the timeout occurs, the client will display the "Oops!" error message.

We also need to handle request timeouts at the server. Simply timing out a request from the client does not stop the server from trying to process the request (and calling OpenAI), only to produce a result that will be in vain. Thus, right before we call the Chain, we check to see if the timeout has already occurred. If so, we return an error instead of executing the request.

I also made some minor changes to the front-end:
- Updated the CSS to add the same padding for "Oops!" messages as we have in regular messages (previously, the "Oops!" messages had no space between the A2rchi profile pic and the start of the text, which looked bad)
- I added a `try-catch` block around our `fetch` calls for `likeResponse` and `dislikeResponse`, as these methods will currently fail if/when a user likes/dislikes an "Oops!" message.