### PR TITLE
Add Firefox and Geckodriver deps to Dockerfiles for Selenium

### DIFF
--- a/a2rchi/templates/dockerfiles/Dockerfile-chat-gpu
+++ b/a2rchi/templates/dockerfiles/Dockerfile-chat-gpu
@@ -13,6 +13,22 @@ RUN apt-get update && apt-get install -y \
     libnvidia-compute-550 \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Firefox and Geckodriver for Selenium 
+RUN apt-get update && apt-get install -y \
+    firefox-esr \
+    wget \
+    gnupg \
+    ca-certificates \
+    --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Geckodriver
+RUN wget -q "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz" \
+    && tar -xzf "geckodriver-v0.36.0-linux64.tar.gz" -C /usr/local/bin \
+    && chmod +x /usr/local/bin/geckodriver \
+    && rm "geckodriver-v0.36.0-linux64.tar.gz"
+
 COPY a2rchi_code a2rchi
 COPY pyproject.toml pyproject.toml
 COPY weblists weblists

--- a/a2rchi/templates/dockerfiles/Dockerfile-grader-gpu
+++ b/a2rchi/templates/dockerfiles/Dockerfile-grader-gpu
@@ -14,6 +14,22 @@ RUN apt-get update && apt-get install -y \
     libnvidia-compute-550 \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Firefox and Geckodriver for Selenium 
+RUN apt-get update && apt-get install -y \
+    firefox-esr \
+    wget \
+    gnupg \
+    ca-certificates \
+    --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Geckodriver
+RUN wget -q "https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz" \
+    && tar -xzf "geckodriver-v0.36.0-linux64.tar.gz" -C /usr/local/bin \
+    && chmod +x /usr/local/bin/geckodriver \
+    && rm "geckodriver-v0.36.0-linux64.tar.gz"
+
 COPY a2rchi_code a2rchi
 COPY pyproject.toml pyproject.toml
 COPY weblists weblists


### PR DESCRIPTION
This PR is to fix the dependency for Selenium required for web scraping for GPU and grader-gpu modes