### PR TITLE
Make frontend be able to talk to https APIs

### DIFF
--- a/a2rchi/interfaces/chat_app/static/script.js-template
+++ b/a2rchi/interfaces/chat_app/static/script.js-template
@@ -94,7 +94,10 @@ const refreshChat = async () => {
 }
 
 const getChatResponse = async (incomingChatDiv, isRefresh=false) => {
-    const API_URL = "http://XX-HOSTNAME-XX:XX-HTTP_PORT-XX/api/get_chat_response";
+    const HOSTNAME = "XX-HOSTNAME-XX";
+    const HTTP_PORT = "XX-HTTP_PORT-XX";
+    const PROTOCOL = HTTP_PORT === "443" ? "https" : "http";
+    const API_URL = `${PROTOCOL}://${HOSTNAME}:${HTTP_PORT}/api/get_chat_response`;
     const pElement = document.createElement("div");
 
      // Define the properties and data for the API request


### PR DESCRIPTION
This PR updates the way the frontend js template constructs the API url. If the `interfaces.chat_app.EXTERNAL_PORT` is set to 443, it uses https, o/w http