### PR TITLE
Permissions for OpenShift/OKD

### DIFF
--- a/a2rchi/templates/dockerfiles/Dockerfile-chat
+++ b/a2rchi/templates/dockerfiles/Dockerfile-chat
@@ -33,4 +33,6 @@ COPY pyproject.toml pyproject.toml
 COPY weblists weblists
 RUN pip install --upgrade pip && pip install .
 
+RUN chmod g+rx /root; chmod -R g+w /root/A2rchi/a2rchi/interfaces
+
 CMD ["python", "-u", "a2rchi/bin/service_chat.py"]

--- a/a2rchi/templates/dockerfiles/Dockerfile-chroma
+++ b/a2rchi/templates/dockerfiles/Dockerfile-chroma
@@ -2,4 +2,7 @@
 FROM ghcr.io/chroma-core/chroma:0.4.12
 RUN apt-get update -y && apt-get install -y curl
 
+# permissions for OpenShift/OKD
+RUN chmod g+rx /root; chmod -R g+rwx /chroma
+
 CMD ["uvicorn", "chromadb.app:app", "--reload", "--workers", "1", "--host", "0.0.0.0", "--port", "8000", "--log-config", "chromadb/log_config.yml"]


### PR DESCRIPTION
OpenShift and OKD run pods as an ephemeral user with GID 0 rather than root.