### PR TITLE
Set num_gpu to -1 for Ollama

### DIFF
--- a/a2rchi/templates/base-config.yaml
+++ b/a2rchi/templates/base-config.yaml
@@ -168,7 +168,7 @@ chains:
           temperature: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.temperature | default(0.6, true) }}
           top_p: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.top_p | default(0.95, true) }}
           top_k: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.top_k | default(50, true) }}
-          num_gpu: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.num_gpu | default(1, true) }} # may want to make this autodetectable somehow
+          num_gpu: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.num_gpu | default(-1, true) }} # may want to make this autodetectable somehow
           repeat_penalty: {{ chains.chain.MODEL_CLASS_MAP.OllamaInterface.kwargs.repeat_penalty | default(1.0, true) }} 
     chain_update_time: {{ chains.chain.chain_update_time | default(10, true) }}
 


### PR DESCRIPTION
num_gpu is how many layers the model should offload to the GPU - we should let Ollama autoconfigure this as the default.