### PR TITLE
quick change to allow changing postgres port for hostmode

### DIFF
--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -265,11 +265,13 @@ class TemplateManager:
         grafana_dir.mkdir(exist_ok=True)
 
         grafana_pg_password = context.secrets_manager.get_secret("GRAFANA_PG_PASSWORD")
+        postgres_port = context.config_manager.config.get("services", {}).get("postgres", {}).get("port", 5432)
 
         datasources_template = self.env.get_template(BASE_GRAFANA_DATASOURCES_TEMPLATE)
         datasources = datasources_template.render(
             grafana_pg_password=grafana_pg_password,
             host_mode=context.plan.host_mode,
+            postgres_port=postgres_port,
         )
         with open(grafana_dir / "datasources.yaml", "w") as f:
             f.write(datasources)
@@ -343,6 +345,7 @@ class TemplateManager:
     def _render_compose_file(self, context: TemplateContext) -> None:
         template_vars = context.plan.to_template_vars()
         template_vars.update(self._extract_port_config(context))
+        template_vars.setdefault("postgres_port", context.config_manager.config.get("services", {}).get("postgres", {}).get("port", 5432))
 
         # Compose template still expects optional lists
         template_vars.setdefault("prompt_files", [])

--- a/src/cli/templates/base-compose.yaml
+++ b/src/cli/templates/base-compose.yaml
@@ -37,6 +37,9 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/pg_password
       POSTGRES_USER: a2rchi
       POSTGRES_DB: a2rchi-db
+      {% if host_mode -%}
+      PGPORT: {{ postgres_port }}
+      {% endif %}
     secrets:
       - pg_password
     volumes:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -60,7 +60,7 @@ services:
     imap4_port: {{ services.redmine_mailbox.imap4_port | default(143, true) }}
     mailbox_update_time: {{ services.redmine_mailbox.mailbox_update_time | default(10, true) }}
   postgres:
-    port: {{ services.postgres.port | default(5432, true) }}
+    port: {{ services.postgres.port if host_mode else 5432 }}
     user: {{ services.postgres.user | default('a2rchi', true) }}
     database: {{ services.postgres.database | default('a2rchi-db', true) }}
     host: {{ 'localhost' if host_mode else (utils.postgres.host | default('postgres', true)) }}

--- a/src/cli/templates/grafana/datasources.yaml
+++ b/src/cli/templates/grafana/datasources.yaml
@@ -3,7 +3,7 @@ apiVersion: 1
 datasources:
   - name: Postgres
     type: postgres
-    url: {{ 'localhost:5432' if host_mode else 'postgres:5432' }}
+    url: {{ 'localhost' if host_mode else 'postgres' }}:{{ postgres_port }}
     user: grafana
     secureJsonData:
       password: {{ grafana_pg_password }}


### PR DESCRIPTION
`services: postgres: port` in the config will change postgres port. ignored if not running on `--hostmode`.

this is just a quick fix to help test on one of our development machines, fixing and organizing how ports are handled will follow in another PR.