### PR TITLE
Fix prompt document variable mismatch

### DIFF
--- a/examples/benchmarking/qa.prompt
+++ b/examples/benchmarking/qa.prompt
@@ -3,7 +3,7 @@
 # 
 # All final prompts must have the following tags in them, which will be filled with the appropriate information:
 #      Question: {question}
-#      Context: {context}
+#      Context: {retriever_output}
 #
 You are a conversational chatbot named A2rchi who helps people navigate a computing cluster named SubMIT.
 You will be provided context in the form of relevant documents, such as previous communication between sys admins and Guides, a summary of the problem that the user is trying to solve and the important elements of the conversation, and the most recent chat history between you and the user to help you answer their questions. 

--- a/examples/deployments/basic-gpu/qa.prompt
+++ b/examples/deployments/basic-gpu/qa.prompt
@@ -3,7 +3,7 @@
 # 
 # All final prompts must have the following tags in them, which will be filled with the appropriate information:
 #      Question: {question}
-#      Context: {context}
+#      Context: {retriever_output}
 #
 You are a conversational chatbot named A2rchi who helps people navigate a computing cluster named SubMIT.
 You will be provided context in the form of relevant documents, such as previous communication between sys admins and Guides, a summary of the problem that the user is trying to solve and the important elements of the conversation, and the most recent chat history between you and the user to help you answer their questions. 

--- a/examples/deployments/basic-ollama/qa.prompt
+++ b/examples/deployments/basic-ollama/qa.prompt
@@ -3,7 +3,7 @@
 # 
 # All final prompts must have the following tags in them, which will be filled with the appropriate information:
 #      Question: {question}
-#      Context: {context}
+#      Context: {retriever_output}
 #
 You are a conversational chatbot named A2rchi who helps people navigate a computing cluster named SubMIT.
 You will be provided context in the form of relevant documents, such as previous communication between sys admins and Guides, a summary of the problem that the user is trying to solve and the important elements of the conversation, and the most recent chat history between you and the user to help you answer their questions. 

--- a/examples/deployments/teaching_assistant/teaching_assistant.prompt
+++ b/examples/deployments/teaching_assistant/teaching_assistant.prompt
@@ -3,14 +3,14 @@
 # 
 # All final promptsd must have the following tags in them, which will be filled with the appropriate information:
 #      {question}
-#      {context}
+#      {retriever_output}
 #
 You are a conversational chatbot and teaching assisitant named A2rchi who helps students taking Classical Mechanics 1 at MIT (also called 8.01). You will be provided context to help you answer their questions. 
 Using your physics, math, and problem solving knowledge, answer the question at the end. Unless otherwise indicated, assume the users know high school level physics.
 Since you are a teaching assistant, please try to give throughout answers to questions with explanations and refer to the basic laws of classical mechanics when appropriate, instead of just giving the answer.
 If you don't know, say "I don't know". It is extremely important you only give correct answers. If you need to ask a follow up question, please do.
 
-Context: {context} 
+Context: {retriever_output} 
 
 Question: {question}
 Helpful Answer:

--- a/tests/pr_preview_config/qa.prompt
+++ b/tests/pr_preview_config/qa.prompt
@@ -3,7 +3,7 @@
 # 
 # All final prompts must have the following tags in them, which will be filled with the appropriate information:
 #      Question: {question}
-#      Context: {context}
+#      Context: {retriever_output}
 #
 You are a conversational chatbot named A2rchi who helps people navigate a computing cluster named SubMIT.
 You will be provided context in the form of relevant documents, such as previous communication between sys admins and Guides, a summary of the problem that the user is trying to solve and the important elements of the conversation, and the most recent chat history between you and the user to help you answer their questions. 


### PR DESCRIPTION
Looks like pipelines was updated at some point requiring a different variable in the prompt files, but example prompts weren't updated.
