### PR TITLE
Modified pr_preview to make it compatible with the submit76 runner.

### DIFF
--- a/.github/actions/run-smoke/action.yml
+++ b/.github/actions/run-smoke/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: Base URL passed to smoke.sh via BASE_URL.
     required: false
     default: http://localhost:7861
+  use-podman:
+    description: Use podman instead of docker.
+    required: false
+    default: "false"
 
 outputs:
   deployment-name:
@@ -87,6 +91,7 @@ runs:
         SERVICES: ${{ inputs.services }}
         HOSTMODE: ${{ inputs.hostmode }}
         ENV_FILE: ${{ inputs.env-file }}
+        USE_PODMAN: ${{ inputs.use-podman }}
       run: |
         set -euo pipefail
         if [[ -n "${EXTRA_ENV}" ]]; then
@@ -97,6 +102,9 @@ runs:
           done <<< "${EXTRA_ENV}"
         fi
         CMD=(a2rchi create --name "${DEPLOYMENT_NAME}" --config "${CONFIG_DEST}" -v 4 --services "${SERVICES}" --env-file "${ENV_FILE}")
+        if [[ "${USE_PODMAN,,}" == "true" ]]; then
+          CMD+=(--podman)
+        fi
         if [[ "${HOSTMODE,,}" == "true" ]]; then
           CMD+=(--hostmode)
         fi
@@ -163,6 +171,7 @@ runs:
         EXTRA_ENV: ${{ inputs.extra-env }}
         ENV_FILE: ${{ inputs.env-file }}
         CONFIG_DEST: ${{ inputs.config-destination }}
+        USE_PODMAN: ${{ inputs.use-podman }}
       run: |
         set +e
         if [[ -n "${EXTRA_ENV}" ]]; then
@@ -173,7 +182,11 @@ runs:
           done <<< "${EXTRA_ENV}"
         fi
         if [[ -n "${DEPLOYMENT_NAME}" ]]; then
-          a2rchi delete --name "${DEPLOYMENT_NAME}" || true
+          if [[ "${USE_PODMAN,,}" == "true" ]]; then
+            yes | a2rchi delete --name "${DEPLOYMENT_NAME}" --podman --rmi --rmv || true
+          else
+            a2rchi delete --name "${DEPLOYMENT_NAME}" || true
+          fi
+          sleep 2
         fi
         rm -f "${ENV_FILE}"
-        # Leave copied config in place for debugging if needed.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   # formatting:
-  #   runs-on: ubuntu-latest
+  #   runs-on: [submit76-runner]
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v4
@@ -29,12 +30,12 @@ jobs:
   #       run: black --check .
 
   build-base-images:
-    runs-on: ubuntu-latest
+    runs-on: [submit76-runner]
     permissions:
       contents: read
     env:
-      A2RCHI_DIR: /home/runner/work/a2rchi-local
-      HOME: /home/runner
+      A2RCHI_DIR: ${{ github.workspace }}/a2rchi-local
+ 
     outputs:
       changed: ${{ steps.detect.outputs.changed }}
       tag: ${{ steps.detect.outputs.tag }}
@@ -68,11 +69,19 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Python
-        if: steps.detect.outputs.changed == 'true'
+      - name: Set up Python (GitHub runner)
+        if: ${{ !contains(runner.name, 'submit') && steps.detect.outputs.changed == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Set up Python (Self-hosted)
+        if: ${{ contains(runner.name, 'submit') && steps.detect.outputs.changed == 'true' }} 
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+          python3 --version
 
       - name: Install a2rchi CLI
         if: steps.detect.outputs.changed == 'true'
@@ -97,24 +106,32 @@ jobs:
         run: scripts/dev/push_docker_images.sh "${{ steps.detect.outputs.tag }}"
 
   preview:
-    runs-on: ubuntu-latest
+    runs-on: [submit76-runner]
     needs: build-base-images
     permissions:
       contents: read
       pull-requests: write
     env:
-      A2RCHI_DIR: /home/runner/work/a2rchi-local
-      HOME: /home/runner
+      A2RCHI_DIR: ${{ github.workspace }}/a2rchi-local
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
+      - name: Set up Python (GitHub runner)
+        if: ${{ !contains(runner.name, 'submit') && steps.detect.outputs.changed == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Set up Python (Self-hosted)
+        if: ${{ contains(runner.name, 'submit') && steps.detect.outputs.changed == 'true' }}
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+          python3 --version
 
       - name: Install a2rchi CLI
         run: |
@@ -140,9 +157,10 @@ jobs:
           env-file: .env
           services: chatbot
           hostmode: "true"
-          wait-url: http://localhost:7861/api/health
-          base-url: http://localhost:7861
-          extra-env: A2RCHI_COMPOSE_UP_FLAGS=--build --pull always
+          wait-url: http://localhost:27861/api/health
+          base-url: http://localhost:27861
+          extra-env: A2RCHI_COMPOSE_UP_FLAGS=--build --pull
+          use-podman: "true"
 
       - name: Delete PR preview Docker tags
         if: ${{ always() && needs.build-base-images.outputs.changed == 'true' }}

--- a/tests/pr_preview_config/pr_preview_config.yaml
+++ b/tests/pr_preview_config/pr_preview_config.yaml
@@ -1,7 +1,11 @@
 name: pr_preview_config
 
 services:
+  postgres:
+    port: 34567
   chat_app:
+    port: 27861
+    external_port: 27861
     trained_on: "Dummy data for preview"
 
 data_manager:


### PR DESCRIPTION
Hello,

This is the PR for migrating the existing pr_review pipeline to use the self-hosted runner that I installed and set up on the submit76 machine.
There are a few changes that I’ve applied.

First, the actions/setup-python@v5 step that normally installs a specific Python version when the pipeline detects an image change is not compatible with the submit runner. So I added a condition so that when the pipeline is running on our runner, it uses the Python version I installed with pyenv on the machine (Python 3.11.14).

Second, the submit machine uses Podman as the container manager, so I updated the pipeline to be compatible with both Docker and Podman. Right now the pipeline in this PR runs using Podman commands, but if we switch to Docker in the future, we can easily adjust the pipeline options to support Docker instead.

Third, the submit machine isn’t an empty environment, and the default ports for the chat service (7861) and PostgreSQL (5432) are already being used by other processes. So I changed the ports the pipeline uses when it runs on the machine.

These are the main changes needed to make the pipeline compatible with the submit runner.

Thank you so much, and please feel free to leave any comments or suggestions.