### PR TITLE
Testing manual label addition to the runner

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
   #       run: black --check .
   # test add label
   build-base-images:
-    runs-on: [submit76]
+    runs-on: [self-hosted]
     permissions:
       contents: read
     env:
@@ -106,7 +106,7 @@ jobs:
         run: scripts/dev/push_docker_images.sh "${{ steps.detect.outputs.tag }}"
 
   preview:
-    runs-on: [submit76]
+    runs-on: [self-hosted]
     needs: build-base-images
     permissions:
       contents: read


### PR DESCRIPTION
Regarding seeing some jobs in the queue waiting for machines with the label submit76-runner: I think the problem is a mismatch between the machine’s label and the GitHub request, so I tried adding the label manually in the GitHub UI and testing it.