### PR TITLE
fix for missing archi logo

### DIFF
--- a/src/interfaces/chat_app/static/images/archi-logo.png
+++ b/src/interfaces/chat_app/static/images/archi-logo.png
@@ -1,0 +1,1 @@
+archi.png


### PR DESCRIPTION
fix for missing archi logo on the top left