### PR TITLE
Fix issue of local provider always pointing to default ollama url

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -623,6 +623,7 @@ class BaseReActAgent:
         """Initialise language models declared for the pipeline."""
 
         models_config = self.pipeline_config.get("models", {})
+        providers_config = self.archi_config.get("providers",{})
         self.llms: Dict[str, Any] = {}
 
         all_models = dict(models_config.get("required", {}), **models_config.get("optional", {}))
@@ -639,7 +640,8 @@ class BaseReActAgent:
                 continue
 
             provider, model_id = self._parse_provider_model(model_class_name)
-            instance = get_model(provider, model_id)
+            provider_config = providers_config.get(provider,{})
+            instance = get_model(provider, model_id, provider_config)
             self.llms[model_name] = instance
             initialised_models[model_class_name] = instance
 

--- a/src/archi/providers/__init__.py
+++ b/src/archi/providers/__init__.py
@@ -204,7 +204,7 @@ def list_all_models() -> Dict[str, List[ModelInfo]]:
     return result
 
 
-def get_model(provider_type: str | ProviderType, model_name: str, **kwargs):
+def get_model(provider_type: str | ProviderType, model_name: str, provider_config: dict, **kwargs):
     """
     Convenience function to get a chat model directly.
     
@@ -216,7 +216,14 @@ def get_model(provider_type: str | ProviderType, model_name: str, **kwargs):
     Returns:
         A LangChain chat model instance
     """
-    provider = get_provider(provider_type)
+    config = ProviderConfig(
+        provider_type = provider_type,
+        base_url = provider_config.get("base_url",None),
+        enabled=True,
+        models = provider_config.get("models",[]),
+        default_model = provider_config.get("default_model",None)
+    )
+    provider = get_provider(provider_type,config)
     return provider.get_chat_model(model_name, **kwargs)
 
 


### PR DESCRIPTION
Fixes issue #435 by passing down the provider config when the model instance is created.