### PR TITLE
fix: make shlex.split() platform-aware for Windows path support

### DIFF
--- a/src/cli/utils/command_runner.py
+++ b/src/cli/utils/command_runner.py
@@ -1,3 +1,4 @@
+import os
 import shlex
 import subprocess
 import threading
@@ -14,7 +15,8 @@ class CommandRunner:
     @staticmethod
     def run_simple(command_str: str, cwd: Path = None) -> Tuple[str, str, int]:
         """Simple command execution - no streaming"""
-        command_list = shlex.split(command_str)
+        posix = os.name == 'posix'
+        command_list = shlex.split(command_str, posix=posix)
         logger.debug(f"Executing command: {command_str}")
         
         process = subprocess.Popen(
@@ -34,7 +36,8 @@ class CommandRunner:
     @staticmethod
     def run_streaming(command_str: str, cwd: Path = None) -> Tuple[str, str, int]:
         """Run command with real-time output streaming and proper exit code handling"""
-        command_list = shlex.split(command_str)
+        posix = os.name == 'posix'
+        command_list = shlex.split(command_str, posix=posix)
         
         logger.debug(f"Executing command: {command_str}")
         


### PR DESCRIPTION
# Fix: Make `shlex.split()` platform-aware for Windows path support

## Problem

`shlex.split()` defaults to POSIX mode, which treats backslashes as escape characters. On Windows, this corrupts file paths:

```
C:\Users\username\.archi\config.yaml  →  C:UsersusernameArchiconfigyaml
```

This causes `archi create` to fail on Windows because Docker compose commands receive mangled paths.

## Fix

Pass `posix=os.name == 'posix'` to `shlex.split()` in both `run_simple()` and `run_streaming()` methods. On Linux/macOS, behavior is unchanged.

## Changes

- `src/cli/utils/command_runner.py` — 3 lines changed (1 import, 2 method fixes)

## Testing

- Verified `archi create` completes successfully on Windows
- All 3 Docker containers (chatbot, data-manager, postgres) start and run correctly

