### PR TITLE
Auto-trim history based on provider context window (issue399)

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -1196,7 +1196,7 @@ class BaseReActAgent:
         chunk = older[:chunk_size]
 
         summary = self._summarize_messages(chunk)
-        summary_message = SystemMessage(content="Summary of earlier conversation:\n" + summary)
+        summary_message = AIMessage(content="Summary of earlier conversation:\n" + summary)
         return [summary_message] + older[chunk_size:] + recent
 
 


### PR DESCRIPTION
Add function to extract the context window of the model, then trim the history context based on it. 