### PR TITLE
Handle GraphRecursionError with Luca's commit `ea6f082`

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -1113,8 +1113,18 @@ class BaseReActAgent:
         )
 
     def _recursion_limit(self) -> int:
-        """Read and validate recursion limit from pipeline config."""
-        value = self.pipeline_config.get("recursion_limit", self.DEFAULT_RECURSION_LIMIT)
+        """Read and validate recursion limit from config."""
+        value = None
+        if isinstance(self.pipeline_config, dict):
+            value = self.pipeline_config.get("recursion_limit")
+        if value is None and isinstance(self.config, dict):
+            services_cfg = self.config.get("services", {})
+            if isinstance(services_cfg, dict):
+                chat_cfg = services_cfg.get("chat_app", {})
+                if isinstance(chat_cfg, dict):
+                    value = chat_cfg.get("recursion_limit")
+        if value is None:
+            value = self.DEFAULT_RECURSION_LIMIT
         try:
             limit = int(value)
             if limit <= 0:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -73,6 +73,7 @@ services:
   chat_app:
     agent_class: {{ services.chat_app.agent_class | default("CMSCompOpsAgent", true) }}
     agents_dir: "{{ services.chat_app.agents_dir | default('', true) }}"
+    recursion_limit: {{ services.chat_app.recursion_limit | default(50, true) }}
     default_provider: {{ services.chat_app.default_provider | default("local", true) }}
     default_model: {{ services.chat_app.default_model | default("llama3.2", true) }}
     skills_dir: "{{ services.chat_app.skills_dir | default('', true) }}"


### PR DESCRIPTION
Fixes #448 

Proof that it works:

<img width="832" height="701" alt="Screenshot 2026-02-20 at 14 05 28" src="https://github.com/user-attachments/assets/2eb21439-7c6c-4237-819f-27199c07645f" />

Log:
```
(2026-02-20 13:02:03,039) [src.archi.pipelines.agents.base_react] WARNING: Recursion limit hit during stream for CMSCompOpsAgent (limit=3): Recursion limit of 3 reached without hitting a stop condition. You can increase the limit by setting the `recursion_limit` config key.
```