### PR TITLE
refactor: Enhance context overflow handling in BaseReActAgent with retry logic and graceful responses

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -463,9 +463,38 @@ class BaseReActAgent:
             )
             yield recursion_output
             return
-        
+        except Exception as exc:
+            if not self._is_context_overflow_error(exc):
+                raise
+            logger.warning(
+                "Context overflow during stream for %s: %s",
+                self.__class__.__name__,
+                exc,
+            )
+            if thinking_step_id is not None:
+                duration_ms = int((time.time() - thinking_start_time) * 1000) if thinking_start_time else 0
+                yield self.finalize_output(
+                    answer="",
+                    memory=self.active_memory,
+                    messages=[],
+                    metadata={
+                        "event_type": "thinking_end",
+                        "step_id": thinking_step_id,
+                        "duration_ms": duration_ms,
+                        "thinking_content": accumulated_thinking,
+                    },
+                    final=False,
+                )
+            overflow_output = self._handle_context_overflow(
+                error=exc,
+                agent_inputs=agent_inputs,
+                latest_messages=all_messages or latest_messages,
+            )
+            yield overflow_output
+            return
+
         # Final output
-        logger.debug("Stream finished. accumulated_content='%s', all_messages count=%d", 
+        logger.debug("Stream finished. accumulated_content='%s', all_messages count=%d",
                  accumulated_content[:100] if accumulated_content else "", len(all_messages))
         
         # End thinking phase if still active
@@ -706,9 +735,38 @@ class BaseReActAgent:
             )
             yield recursion_output
             return
-        
+        except Exception as exc:
+            if not self._is_context_overflow_error(exc):
+                raise
+            logger.warning(
+                "Context overflow during async stream for %s: %s",
+                self.__class__.__name__,
+                exc,
+            )
+            if thinking_step_id is not None:
+                duration_ms = int((time.time() - thinking_start_time) * 1000) if thinking_start_time else 0
+                yield self.finalize_output(
+                    answer="",
+                    memory=self.active_memory,
+                    messages=[],
+                    metadata={
+                        "event_type": "thinking_end",
+                        "step_id": thinking_step_id,
+                        "duration_ms": duration_ms,
+                        "thinking_content": accumulated_thinking,
+                    },
+                    final=False,
+                )
+            overflow_output = self._handle_context_overflow(
+                error=exc,
+                agent_inputs=agent_inputs,
+                latest_messages=all_messages or latest_messages,
+            )
+            yield overflow_output
+            return
+
         # Final output
-        logger.debug("Async stream finished. accumulated_content='%s', all_messages count=%d", 
+        logger.debug("Async stream finished. accumulated_content='%s', all_messages count=%d",
                  accumulated_content[:100] if accumulated_content else "", len(all_messages))
         
         # End thinking phase if still active
@@ -1375,6 +1433,84 @@ class BaseReActAgent:
         if last_node:
             metadata["last_node"] = last_node
         return metadata
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Return True if *exc* is a context-window / token-limit overflow error."""
+        exc_type = type(exc).__name__
+        exc_str = str(exc)
+        return (
+            "ContextOverflow" in exc_type
+            or "context_length_exceeded" in exc_str
+            or "Input tokens exceed" in exc_str
+            or "maximum context length" in exc_str.lower()
+        )
+
+    def _handle_context_overflow(
+        self,
+        *,
+        error: Exception,
+        agent_inputs: Optional[Dict[str, Any]] = None,
+        latest_messages: Optional[Sequence[BaseMessage]] = None,
+    ) -> "PipelineOutput":
+        """Build a graceful response after a context-window overflow.
+
+        Attempts a single retry with the last user message only; falls back to
+        a plain error message if the retry also fails or is not possible.
+        """
+        # Try a lightweight retry with just the last human message
+        if agent_inputs and "messages" in agent_inputs:
+            original_messages: List[BaseMessage] = list(agent_inputs.get("messages") or [])
+            # Keep only the last human message to stay well within context
+            trimmed: List[BaseMessage] = [m for m in original_messages[-1:] if True]
+            if trimmed:
+                try:
+                    trimmed_inputs = {**agent_inputs, "messages": trimmed}
+                    answer_output = self.agent.invoke(
+                        trimmed_inputs, {"recursion_limit": 10}
+                    )
+                    messages_out: List[BaseMessage] = list(
+                        answer_output.get("messages", []) if isinstance(answer_output, dict) else []
+                    )
+                    answer_text = ""
+                    for msg in reversed(messages_out):
+                        msg_type = str(getattr(msg, "type", "")).lower()
+                        if msg_type in {"ai", "assistant"} or "ai" in type(msg).__name__.lower():
+                            answer_text = self._message_content(msg)
+                            if answer_text:
+                                break
+                    if answer_text:
+                        logger.info(
+                            "Context overflow retry succeeded for %s.",
+                            self.__class__.__name__,
+                        )
+                        return self.finalize_output(
+                            answer=answer_text,
+                            memory=self.active_memory,
+                            messages=messages_out,
+                            metadata={"event_type": "final", "context_overflow_retry": True},
+                            final=True,
+                        )
+                except Exception as retry_exc:
+                    logger.warning(
+                        "Context overflow retry also failed for %s: %s",
+                        self.__class__.__name__,
+                        retry_exc,
+                    )
+
+        fallback_msg = AIMessage(
+            content=(
+                "I'm sorry, but the conversation history has grown too large for me to process. "
+                "Please start a new conversation to continue."
+            )
+        )
+        return self.finalize_output(
+            answer=self._message_content(fallback_msg),
+            memory=self.active_memory,
+            messages=list(latest_messages or []) + [fallback_msg],
+            metadata={"event_type": "error", "error_type": "context_overflow"},
+            final=True,
+        )
 
     def _handle_recursion_limit_error(
         self,


### PR DESCRIPTION
Chat response fails if tool call returns data that is more than the context window of the LLM model.


```
(2026-03-03 16:03:58,337) [httpx] INFO: HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 400 Bad Request"
(2026-03-03 16:03:58,339) [src.interfaces.chat_app.app] ERROR: Failed to stream response: Error code: 400 - {'error': {'message': 'Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 443733 tokens. Please reduce the length of the messages.', 'type': 'invalid_request_error', 'param': 'messages', 'code': 'context_length_exceeded'}}
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/langchain_openai/chat_models/base.py", line 1391, in _stream
    response = self.client.create(**payload)
  File "/usr/local/lib/python3.10/site-packages/openai/_utils/_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/openai/resources/chat/completions/completions.py", line 1192, in create
    return self._post(
  File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1297, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/usr/local/lib/python3.10/site-packages/openai/_base_client.py", line 1070, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': 'Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 443733 tokens. Please reduce the length of the messages.', 'type': 'invalid_request_error', 'param': 'messages', 'code': 'context_length_exceeded'}}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/src/interfaces/chat_app/app.py", line 1698, in stream
    for output in self.archi.stream(history=context.history, conversation_id=context.conversation_id):
  File "/usr/local/lib/python3.10/site-packages/src/archi/archi.py", line 100, in stream
    for event in self.pipeline.stream(*args, **call_kwargs):
  File "/usr/local/lib/python3.10/site-packages/src/archi/pipelines/agents/base_react.py", line 304, in stream
    for event in self.agent.stream(
  File "/usr/local/lib/python3.10/site-packages/langgraph/pregel/main.py", line 2679, in stream
    for _ in runner.tick(
  File "/usr/local/lib/python3.10/site-packages/langgraph/pregel/_runner.py", line 258, in tick
    _panic_or_proceed(
  File "/usr/local/lib/python3.10/site-packages/langgraph/pregel/_runner.py", line 520, in _panic_or_proceed
    raise exc
  File "/usr/local/lib/python3.10/site-packages/langgraph/pregel/_executor.py", line 80, in done
    task.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/site-packages/langgraph/pregel/_retry.py", line 42, in run_with_retry
    return task.proc.invoke(task.input, config)
  File "/usr/local/lib/python3.10/site-packages/langgraph/_internal/_runnable.py", line 656, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/langgraph/_internal/_runnable.py", line 400, in invoke
    ret = self.func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/langchain/agents/factory.py", line 1065, in model_node
    response = _execute_model_sync(request)
  File "/usr/local/lib/python3.10/site-packages/langchain/agents/factory.py", line 1038, in _execute_model_sync
    output = model_.invoke(messages)
  File "/usr/local/lib/python3.10/site-packages/langchain_core/runnables/base.py", line 5695, in invoke
    return self.bound.invoke(
  File "/usr/local/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 402, in invoke
    self.generate_prompt(
  File "/usr/local/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 1121, in generate_prompt
    return self.generate(prompt_messages, stop=stop, callbacks=callbacks, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 931, in generate
    self._generate_with_cache(
  File "/usr/local/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 1190, in _generate_with_cache
    for chunk in self._stream(messages, stop=stop, **kwargs):
  File "/usr/local/lib/python3.10/site-packages/langchain_openai/chat_models/base.py", line 1416, in _stream
    _handle_openai_bad_request(e)
  File "/usr/local/lib/python3.10/site-packages/langchain_openai/chat_models/base.py", line 499, in _handle_openai_bad_request
    raise OpenAIContextOverflowError(
langchain_openai.chat_models.base.OpenAIContextOverflowError: Error code: 400 - {'error': {'message': 'Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 443733 tokens. Please reduce the length of the messages.', 'type': 'invalid_request_error', 'param': 'messages', 'code': 'context_length_exceeded'}}
(2026-03-03 16:03:58,348) [src.interfaces.chat_app.app] DEBUG: Updated agent trace 3b175029-19c1-47c5-912d-1984735568eb: status=error
```

<img width="993" height="812" alt="image" src="https://github.com/user-attachments/assets/c7e54e97-6662-42f9-b903-732ffde02ad2" />

