### PR TITLE
rename mid to message_id for consistency across schema (#343)

### DIFF
--- a/src/cli/templates/grafana/archi-default-dashboard.json
+++ b/src/cli/templates/grafana/archi-default-dashboard.json
@@ -102,7 +102,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "-- number of messages per 1h window\nWITH msg_timing_info AS (\n  SELECT $__timeGroup(server_received_msg_ts, '1h', 0) as t1, count(mid) as num_msgs\n  FROM timing\n  WHERE $__timeFrom() <= server_received_msg_ts AND server_received_msg_ts <= $__timeTo()\n  GROUP BY 1\n), convo_timing_info AS (\n  SELECT $__timeGroup(server_received_msg_ts, '1h', 0) as t2,\n         COUNT(DISTINCT (meta.client_id || '-' || conversations.conversation_id)) as num_convos\n  FROM timing\n  JOIN conversations ON timing.mid = conversations.message_id\n  JOIN conversation_metadata meta ON conversations.conversation_id = meta.conversation_id\n  WHERE $__timeFrom() <= server_received_msg_ts AND server_received_msg_ts <= $__timeTo()\n  GROUP BY 1\n), intervals AS (\n  SELECT $__timeGroupAlias(t, '1h', 0) FROM generate_series($__timeFrom(), $__timeTo(), '1 hour'::interval) AS s(t)\n), msgs_join_convos AS (\n  SELECT * FROM msg_timing_info JOIN convo_timing_info ON t1 = t2\n)\nSELECT time, num_msgs, num_convos FROM intervals LEFT OUTER JOIN msgs_join_convos ON t1 = intervals.time;\n",
+          "rawSql": "-- number of messages per 1h window\nWITH msg_timing_info AS (\n  SELECT $__timeGroup(server_received_msg_ts, '1h', 0) as t1, count(message_id) as num_msgs\n  FROM timing\n  WHERE $__timeFrom() <= server_received_msg_ts AND server_received_msg_ts <= $__timeTo()\n  GROUP BY 1\n), convo_timing_info AS (\n  SELECT $__timeGroup(server_received_msg_ts, '1h', 0) as t2,\n         COUNT(DISTINCT (meta.client_id || '-' || conversations.conversation_id)) as num_convos\n  FROM timing\n  JOIN conversations ON timing.message_id = conversations.message_id\n  JOIN conversation_metadata meta ON conversations.conversation_id = meta.conversation_id\n  WHERE $__timeFrom() <= server_received_msg_ts AND server_received_msg_ts <= $__timeTo()\n  GROUP BY 1\n), intervals AS (\n  SELECT $__timeGroupAlias(t, '1h', 0) FROM generate_series($__timeFrom(), $__timeTo(), '1 hour'::interval) AS s(t)\n), msgs_join_convos AS (\n  SELECT * FROM msg_timing_info JOIN convo_timing_info ON t1 = t2\n)\nSELECT time, num_msgs, num_convos FROM intervals LEFT OUTER JOIN msgs_join_convos ON t1 = intervals.time;\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -188,7 +188,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  t.server_received_msg_ts AS time,\n  COALESCE(c.model_used, 'unknown') AS metric,\n  EXTRACT(EPOCH FROM t.msg_duration) AS value\nFROM timing t\nJOIN conversations c ON t.mid = c.message_id\nWHERE $__timeFilter(t.server_received_msg_ts)\nORDER BY time",
+          "rawSql": "SELECT\n  t.server_received_msg_ts AS time,\n  COALESCE(c.model_used, 'unknown') AS metric,\n  EXTRACT(EPOCH FROM t.msg_duration) AS value\nFROM timing t\nJOIN conversations c ON t.message_id = c.message_id\nWHERE $__timeFilter(t.server_received_msg_ts)\nORDER BY time",
           "refId": "A",
           "sql": {
             "columns": [
@@ -325,7 +325,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "WITH msg_to_model AS (\n  SELECT c.message_id,\n         COALESCE(c.model_used, 'unknown') AS model_name\n  FROM conversations c\n),\nfeedback_by_model AS (\n  SELECT f.feedback,\n         mtm.model_name\n  FROM feedback f\n  JOIN msg_to_model mtm ON f.mid = mtm.message_id\n  WHERE f.feedback IN ('like', 'dislike')\n)\nSELECT \n  COUNT(*) AS count,\n  feedback || '_' || model_name AS feedback,\n  model_name\nFROM feedback_by_model\nGROUP BY feedback, model_name\nORDER BY model_name,\n         CASE feedback WHEN 'like' THEN 1 ELSE 2 END;\n",
+          "rawSql": "WITH msg_to_model AS (\n  SELECT c.message_id,\n         COALESCE(c.model_used, 'unknown') AS model_name\n  FROM conversations c\n),\nfeedback_by_model AS (\n  SELECT f.feedback,\n         mtm.model_name\n  FROM feedback f\n  JOIN msg_to_model mtm ON f.message_id = mtm.message_id\n  WHERE f.feedback IN ('like', 'dislike')\n)\nSELECT \n  COUNT(*) AS count,\n  feedback || '_' || model_name AS feedback,\n  model_name\nFROM feedback_by_model\nGROUP BY feedback, model_name\nORDER BY model_name,\n         CASE feedback WHEN 'like' THEN 1 ELSE 2 END;\n",
           "refId": "A",
           "sql": {
             "columns": [

--- a/src/cli/templates/init.sql
+++ b/src/cli/templates/init.sql
@@ -405,7 +405,7 @@ CREATE INDEX IF NOT EXISTS idx_conversations_model ON conversations(model_used);
 
 -- Feedback on messages
 CREATE TABLE IF NOT EXISTS feedback (
-    mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
     feedback_ts TIMESTAMPTZ NOT NULL,
     feedback TEXT NOT NULL,           -- 'like', 'dislike', 'comment'
     feedback_msg TEXT,                -- Optional text feedback/comment
@@ -413,14 +413,14 @@ CREATE TABLE IF NOT EXISTS feedback (
     unhelpful BOOLEAN,                -- Flag: response didn't help
     inappropriate BOOLEAN,            -- Flag: response was inappropriate
     
-    PRIMARY KEY (mid, feedback_ts)
+    PRIMARY KEY (message_id, feedback_ts)
 );
 
-CREATE INDEX IF NOT EXISTS idx_feedback_mid ON feedback(mid);
+CREATE INDEX IF NOT EXISTS idx_feedback_message_id ON feedback(message_id);
 
 -- Response timing metrics
 CREATE TABLE IF NOT EXISTS timing (
-    mid INTEGER PRIMARY KEY REFERENCES conversations(message_id) ON DELETE CASCADE,
+    message_id INTEGER PRIMARY KEY REFERENCES conversations(message_id) ON DELETE CASCADE,
     client_sent_msg_ts TIMESTAMPTZ NOT NULL,
     server_received_msg_ts TIMESTAMPTZ NOT NULL,
     lock_acquisition_ts TIMESTAMPTZ NOT NULL,
@@ -490,9 +490,9 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON agent_tool_calls(tool_name);
 CREATE TABLE IF NOT EXISTS ab_comparisons (
     comparison_id SERIAL PRIMARY KEY,
     conversation_id INTEGER NOT NULL REFERENCES conversation_metadata(conversation_id) ON DELETE CASCADE,
-    user_prompt_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
-    response_a_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
-    response_b_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    user_prompt_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    response_a_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    response_b_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
     
     -- Model/pipeline info (optional - can be derived from config_*_id if not set)
     model_a VARCHAR(200),

--- a/src/cli/templates/migrations/rename_mid_to_message_id.sql
+++ b/src/cli/templates/migrations/rename_mid_to_message_id.sql
@@ -1,0 +1,17 @@
+-- Migration: Rename 'mid' columns to 'message_id' for consistency
+-- Issue: https://github.com/archi-physics/archi/issues/343
+--
+-- Run this script against existing deployments to update the schema.
+-- New deployments using init.sql already have the correct column names.
+
+-- feedback table: rename 'mid' -> 'message_id'
+ALTER TABLE feedback RENAME COLUMN mid TO message_id;
+ALTER INDEX IF EXISTS idx_feedback_mid RENAME TO idx_feedback_message_id;
+
+-- timing table: rename 'mid' -> 'message_id'
+ALTER TABLE timing RENAME COLUMN mid TO message_id;
+
+-- ab_comparisons table: rename the three *_mid columns
+ALTER TABLE ab_comparisons RENAME COLUMN user_prompt_mid TO user_prompt_message_id;
+ALTER TABLE ab_comparisons RENAME COLUMN response_a_mid TO response_a_message_id;
+ALTER TABLE ab_comparisons RENAME COLUMN response_b_mid TO response_b_message_id;

--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -618,7 +618,7 @@ class ChatWrapper:
         """
         Insert feedback from user for specific message into feedback table.
         """
-        # construct insert_tup (mid, feedback_ts, feedback, feedback_msg, incorrect, unhelpful, inappropriate)
+        # construct insert_tup (message_id, feedback_ts, feedback, feedback_msg, incorrect, unhelpful, inappropriate)
         insert_tup = (
             feedback['message_id'],
             feedback['feedback_ts'],
@@ -677,9 +677,9 @@ class ChatWrapper:
     def create_ab_comparison(
         self,
         conversation_id: int,
-        user_prompt_mid: int,
-        response_a_mid: int,
-        response_b_mid: int,
+        user_prompt_message_id: int,
+        response_a_message_id: int,
+        response_b_message_id: int,
         config_a_id: int,
         config_b_id: int,
         is_config_a_first: bool,
@@ -689,9 +689,9 @@ class ChatWrapper:
         
         Args:
             conversation_id: The conversation this comparison belongs to
-            user_prompt_mid: Message ID of the user's question
-            response_a_mid: Message ID of response A
-            response_b_mid: Message ID of response B
+            user_prompt_message_id: Message ID of the user's question
+            response_a_message_id: Message ID of response A
+            response_b_message_id: Message ID of response B
             config_a_id: Config ID used for response A
             config_b_id: Config ID used for response B
             is_config_a_first: True if config A was the "first" config before randomization
@@ -704,7 +704,7 @@ class ChatWrapper:
         try:
             cursor.execute(
                 SQL_INSERT_AB_COMPARISON,
-                (conversation_id, user_prompt_mid, response_a_mid, response_b_mid,
+                (conversation_id, user_prompt_message_id, response_a_message_id, response_b_message_id,
                  config_a_id, config_b_id, is_config_a_first)
             )
             comparison_id = cursor.fetchone()[0]
@@ -756,9 +756,9 @@ class ChatWrapper:
             return {
                 'comparison_id': row[0],
                 'conversation_id': row[1],
-                'user_prompt_mid': row[2],
-                'response_a_mid': row[3],
-                'response_b_mid': row[4],
+                'user_prompt_message_id': row[2],
+                'response_a_message_id': row[3],
+                'response_b_message_id': row[4],
                 'config_a_id': row[5],
                 'config_b_id': row[6],
                 'is_config_a_first': row[7],
@@ -787,9 +787,9 @@ class ChatWrapper:
             return {
                 'comparison_id': row[0],
                 'conversation_id': row[1],
-                'user_prompt_mid': row[2],
-                'response_a_mid': row[3],
-                'response_b_mid': row[4],
+                'user_prompt_message_id': row[2],
+                'response_a_message_id': row[3],
+                'response_b_message_id': row[4],
                 'config_a_id': row[5],
                 'config_b_id': row[6],
                 'is_config_a_first': row[7],
@@ -837,9 +837,9 @@ class ChatWrapper:
                 {
                     'comparison_id': row[0],
                     'conversation_id': row[1],
-                    'user_prompt_mid': row[2],
-                    'response_a_mid': row[3],
-                    'response_b_mid': row[4],
+                    'user_prompt_message_id': row[2],
+                    'response_a_message_id': row[3],
+                    'response_b_message_id': row[4],
                     'config_a_id': row[5],
                     'config_b_id': row[6],
                     'is_config_a_first': row[7],
@@ -4008,9 +4008,9 @@ class FlaskAppWrapper(object):
 
         POST body:
         - conversation_id: The conversation ID
-        - user_prompt_mid: Message ID of the user's question
-        - response_a_mid: Message ID of response A
-        - response_b_mid: Message ID of response B
+        - user_prompt_message_id: Message ID of the user's question
+        - response_a_message_id: Message ID of response A
+        - response_b_message_id: Message ID of response B
         - config_a_id: Config ID used for response A
         - config_b_id: Config ID used for response B
         - is_config_a_first: True if config A was the "first" config before randomization
@@ -4022,9 +4022,9 @@ class FlaskAppWrapper(object):
         try:
             data = request.json
             conversation_id = data.get('conversation_id')
-            user_prompt_mid = data.get('user_prompt_mid')
-            response_a_mid = data.get('response_a_mid')
-            response_b_mid = data.get('response_b_mid')
+            user_prompt_message_id = data.get('user_prompt_message_id')
+            response_a_message_id = data.get('response_a_message_id')
+            response_b_message_id = data.get('response_b_message_id')
             config_a_id = data.get('config_a_id')
             config_b_id = data.get('config_b_id')
             is_config_a_first = data.get('is_config_a_first', True)
@@ -4034,12 +4034,12 @@ class FlaskAppWrapper(object):
             missing = []
             if not conversation_id:
                 missing.append('conversation_id')
-            if not user_prompt_mid:
-                missing.append('user_prompt_mid')
-            if not response_a_mid:
-                missing.append('response_a_mid')
-            if not response_b_mid:
-                missing.append('response_b_mid')
+            if not user_prompt_message_id:
+                missing.append('user_prompt_message_id')
+            if not response_a_message_id:
+                missing.append('response_a_message_id')
+            if not response_b_message_id:
+                missing.append('response_b_message_id')
             if not config_a_id:
                 missing.append('config_a_id')
             if not config_b_id:
@@ -4053,9 +4053,9 @@ class FlaskAppWrapper(object):
             # Create the comparison
             comparison_id = self.chat.create_ab_comparison(
                 conversation_id=conversation_id,
-                user_prompt_mid=user_prompt_mid,
-                response_a_mid=response_a_mid,
-                response_b_mid=response_b_mid,
+                user_prompt_message_id=user_prompt_message_id,
+                response_a_message_id=response_a_message_id,
+                response_b_message_id=response_b_message_id,
                 config_a_id=config_a_id,
                 config_b_id=config_b_id,
                 is_config_a_first=is_config_a_first,

--- a/src/interfaces/chat_app/static/chat.js
+++ b/src/interfaces/chat_app/static/chat.js
@@ -3551,9 +3551,9 @@ const Chat = {
       // Create A/B comparison record
       const response = await API.createABComparison({
         conversation_id: this.state.conversationId,
-        user_prompt_mid: results.a.userPromptMid || results.b.userPromptMid,
-        response_a_mid: results.a.messageId,
-        response_b_mid: results.b.messageId,
+        user_prompt_message_id: results.a.userPromptMid || results.b.userPromptMid,
+        response_a_message_id: results.a.messageId,
+        response_b_message_id: results.b.messageId,
         config_a_id: configAId,
         config_b_id: configBId,
         is_config_a_first: !shuffled,

--- a/src/utils/conversation_service.py
+++ b/src/utils/conversation_service.py
@@ -43,9 +43,9 @@ class ABComparison:
     """An A/B comparison between two model responses."""
     comparison_id: Optional[int] = None
     conversation_id: str = ""
-    user_prompt_mid: int = 0  # message_id of user prompt
-    response_a_mid: int = 0   # message_id of response A
-    response_b_mid: int = 0   # message_id of response B
+    user_prompt_message_id: int = 0  # message_id of user prompt
+    response_a_message_id: int = 0   # message_id of response A
+    response_b_message_id: int = 0   # message_id of response B
     model_a: str = ""
     pipeline_a: str = ""
     model_b: str = ""
@@ -259,9 +259,9 @@ class ConversationService:
     def create_ab_comparison(
         self,
         conversation_id: str,
-        user_prompt_mid: int,
-        response_a_mid: int,
-        response_b_mid: int,
+        user_prompt_message_id: int,
+        response_a_message_id: int,
+        response_b_message_id: int,
         model_a: str,
         pipeline_a: str,
         model_b: str,
@@ -273,9 +273,9 @@ class ConversationService:
         
         Args:
             conversation_id: Conversation this comparison belongs to
-            user_prompt_mid: Message ID of user prompt
-            response_a_mid: Message ID of response A
-            response_b_mid: Message ID of response B
+            user_prompt_message_id: Message ID of user prompt
+            response_a_message_id: Message ID of response A
+            response_b_message_id: Message ID of response B
             model_a: Model identifier for response A
             pipeline_a: Pipeline identifier for response A
             model_b: Model identifier for response B
@@ -292,9 +292,9 @@ class ConversationService:
                     SQL_INSERT_AB_COMPARISON,
                     (
                         conversation_id,
-                        user_prompt_mid,
-                        response_a_mid,
-                        response_b_mid,
+                        user_prompt_message_id,
+                        response_a_message_id,
+                        response_b_message_id,
                         model_a,
                         pipeline_a,
                         model_b,
@@ -362,9 +362,9 @@ class ConversationService:
                 return ABComparison(
                     comparison_id=row[0],
                     conversation_id=row[1],
-                    user_prompt_mid=row[2],
-                    response_a_mid=row[3],
-                    response_b_mid=row[4],
+                    user_prompt_message_id=row[2],
+                    response_a_message_id=row[3],
+                    response_b_message_id=row[4],
                     model_a=row[5],
                     pipeline_a=row[6],
                     model_b=row[7],
@@ -402,9 +402,9 @@ class ConversationService:
                 return ABComparison(
                     comparison_id=row[0],
                     conversation_id=row[1],
-                    user_prompt_mid=row[2],
-                    response_a_mid=row[3],
-                    response_b_mid=row[4],
+                    user_prompt_message_id=row[2],
+                    response_a_message_id=row[3],
+                    response_b_message_id=row[4],
                     model_a=row[5],
                     pipeline_a=row[6],
                     model_b=row[7],
@@ -443,9 +443,9 @@ class ConversationService:
                     ABComparison(
                         comparison_id=row[0],
                         conversation_id=row[1],
-                        user_prompt_mid=row[2],
-                        response_a_mid=row[3],
-                        response_b_mid=row[4],
+                        user_prompt_message_id=row[2],
+                        response_a_message_id=row[3],
+                        response_b_message_id=row[4],
                         model_a=row[5],
                         pipeline_a=row[6],
                         model_b=row[7],

--- a/src/utils/sql.py
+++ b/src/utils/sql.py
@@ -15,19 +15,19 @@ RETURNING message_id;
 
 SQL_INSERT_FEEDBACK = """
 INSERT INTO feedback (
-    mid, feedback_ts, feedback, feedback_msg, incorrect, unhelpful, inappropriate
+    message_id, feedback_ts, feedback, feedback_msg, incorrect, unhelpful, inappropriate
 )
 VALUES (%s, %s, %s, %s, %s, %s, %s);
 """
 
 SQL_DELETE_REACTION_FEEDBACK = """
 DELETE FROM feedback
-WHERE mid = %s AND feedback IN ('like', 'dislike');
+WHERE message_id = %s AND feedback IN ('like', 'dislike');
 """
 
 SQL_GET_REACTION_FEEDBACK = """
 SELECT feedback FROM feedback
-WHERE mid = %s AND feedback IN ('like', 'dislike')
+WHERE message_id = %s AND feedback IN ('like', 'dislike')
 ORDER BY feedback_ts DESC
 LIMIT 1;
 """
@@ -48,28 +48,28 @@ SELECT c.sender,
        c.model_used
 FROM conversations c
 LEFT JOIN (
-    SELECT DISTINCT ON (mid)
-        mid,
+    SELECT DISTINCT ON (message_id)
+        message_id,
         feedback,
         feedback_ts
     FROM feedback
     WHERE feedback IN ('like', 'dislike')
-    ORDER BY mid, feedback_ts DESC
-) lf ON lf.mid = c.message_id
+    ORDER BY message_id, feedback_ts DESC
+) lf ON lf.message_id = c.message_id
 LEFT JOIN (
-    SELECT mid,
+    SELECT message_id,
            COUNT(*) AS comment_count
     FROM feedback
     WHERE feedback = 'comment'
-    GROUP BY mid
-) cf ON cf.mid = c.message_id
+    GROUP BY message_id
+) cf ON cf.message_id = c.message_id
 WHERE c.conversation_id = %s
 ORDER BY c.message_id ASC;
 """
 
 SQL_INSERT_TIMING = """
 INSERT INTO timing (
-    mid,
+    message_id,
     client_sent_msg_ts,
     server_received_msg_ts,
     lock_acquisition_ts,
@@ -183,7 +183,7 @@ ORDER BY step_number ASC;
 
 SQL_INSERT_AB_COMPARISON = """
 INSERT INTO ab_comparisons (
-    conversation_id, user_prompt_mid, response_a_mid, response_b_mid, 
+    conversation_id, user_prompt_message_id, response_a_message_id, response_b_message_id,
     model_a, pipeline_a, model_b, pipeline_b, is_config_a_first
 )
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
@@ -197,15 +197,15 @@ WHERE comparison_id = %s;
 """
 
 SQL_GET_AB_COMPARISON = """
-SELECT comparison_id, conversation_id, user_prompt_mid, response_a_mid, response_b_mid,
-       model_a, pipeline_a, model_b, pipeline_b, 
+SELECT comparison_id, conversation_id, user_prompt_message_id, response_a_message_id, response_b_message_id,
+       model_a, pipeline_a, model_b, pipeline_b,
        is_config_a_first, preference, preference_ts, created_at
 FROM ab_comparisons
 WHERE comparison_id = %s;
 """
 
 SQL_GET_PENDING_AB_COMPARISON = """
-SELECT comparison_id, conversation_id, user_prompt_mid, response_a_mid, response_b_mid,
+SELECT comparison_id, conversation_id, user_prompt_message_id, response_a_message_id, response_b_message_id,
        model_a, pipeline_a, model_b, pipeline_b,
        is_config_a_first, preference, preference_ts, created_at
 FROM ab_comparisons
@@ -220,7 +220,7 @@ WHERE comparison_id = %s;
 """
 
 SQL_GET_AB_COMPARISONS_BY_CONVERSATION = """
-SELECT comparison_id, conversation_id, user_prompt_mid, response_a_mid, response_b_mid,
+SELECT comparison_id, conversation_id, user_prompt_message_id, response_a_message_id, response_b_message_id,
        model_a, pipeline_a, model_b, pipeline_b,
        is_config_a_first, preference, preference_ts, created_at
 FROM ab_comparisons

--- a/tests/smoke/init-test.sql
+++ b/tests/smoke/init-test.sql
@@ -391,7 +391,7 @@ CREATE INDEX IF NOT EXISTS idx_conversations_model ON conversations(model_used);
 
 -- Feedback on messages
 CREATE TABLE IF NOT EXISTS feedback (
-    mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
     feedback_ts TIMESTAMP NOT NULL,
     feedback TEXT NOT NULL,           -- 'like', 'dislike', 'comment'
     feedback_msg TEXT,                -- Optional text feedback/comment
@@ -399,14 +399,14 @@ CREATE TABLE IF NOT EXISTS feedback (
     unhelpful BOOLEAN,                -- Flag: response didn't help
     inappropriate BOOLEAN,            -- Flag: response was inappropriate
     
-    PRIMARY KEY (mid, feedback_ts)
+    PRIMARY KEY (message_id, feedback_ts)
 );
 
-CREATE INDEX IF NOT EXISTS idx_feedback_mid ON feedback(mid);
+CREATE INDEX IF NOT EXISTS idx_feedback_message_id ON feedback(message_id);
 
 -- Response timing metrics
 CREATE TABLE IF NOT EXISTS timing (
-    mid INTEGER PRIMARY KEY REFERENCES conversations(message_id) ON DELETE CASCADE,
+    message_id INTEGER PRIMARY KEY REFERENCES conversations(message_id) ON DELETE CASCADE,
     client_sent_msg_ts TIMESTAMP NOT NULL,
     server_received_msg_ts TIMESTAMP NOT NULL,
     lock_acquisition_ts TIMESTAMP NOT NULL,
@@ -476,9 +476,9 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON agent_tool_calls(tool_name);
 CREATE TABLE IF NOT EXISTS ab_comparisons (
     comparison_id SERIAL PRIMARY KEY,
     conversation_id INTEGER NOT NULL REFERENCES conversation_metadata(conversation_id) ON DELETE CASCADE,
-    user_prompt_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
-    response_a_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
-    response_b_mid INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    user_prompt_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    response_a_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
+    response_b_message_id INTEGER NOT NULL REFERENCES conversations(message_id) ON DELETE CASCADE,
     
     -- Model/pipeline info (optional - can be derived from config_*_id if not set)
     model_a VARCHAR(200),

--- a/tests/smoke/test_integration.py
+++ b/tests/smoke/test_integration.py
@@ -248,14 +248,14 @@ def test_ab_comparison_v2(test_conv_id):
     )
     
     message_ids = service.insert_messages([prompt_msg, response_a_msg, response_b_msg])
-    user_prompt_mid, response_a_mid, response_b_mid = message_ids
+    user_prompt_message_id, response_a_message_id, response_b_message_id = message_ids
     
     # Create A/B comparison with model info (using correct API)
     comparison_id = service.create_ab_comparison(
         conversation_id=test_conv_id,
-        user_prompt_mid=user_prompt_mid,
-        response_a_mid=response_a_mid,
-        response_b_mid=response_b_mid,
+        user_prompt_message_id=user_prompt_message_id,
+        response_a_message_id=response_a_message_id,
+        response_b_message_id=response_b_message_id,
         model_a="gpt-4o",
         model_b="claude-3-5-sonnet",
         pipeline_a="QAPipeline",

--- a/tests/unit/test_postgres_services.py
+++ b/tests/unit/test_postgres_services.py
@@ -340,9 +340,9 @@ class TestConversationService:
         service = ConversationService(connection_pool=mock_pool)
         comparison_id = service.create_ab_comparison(
             conversation_id="conv123",
-            user_prompt_mid=1,
-            response_a_mid=2,
-            response_b_mid=3,
+            user_prompt_message_id=1,
+            response_a_message_id=2,
+            response_b_message_id=3,
             model_a="gpt-4",
             pipeline_a="QAPipeline",
             model_b="claude-3",


### PR DESCRIPTION
Closes #343

`message_id` was used inconsistently — `conversations` used `message_id` but `feedback`, `timing`, and `ab_comparisons` tables referred to it as `mid` / `*_mid`. This renames everything to `message_id` for clarity.

### Changes
- `src/cli/templates/init.sql` + `tests/smoke/init-test.sql` — schema DDL
- `src/utils/sql.py` — all SQL query constants
- `src/utils/conversation_service.py` — `ABComparison` dataclass + method params
- `src/interfaces/chat_app/app.py` + `static/chat.js` — app logic + API payload keys
- `src/cli/templates/grafana/a2rchi-default-dashboard.json` — dashboard SQL queries
- `src/cli/templates/migrations/rename_mid_to_message_id.sql` — migration script for existing deployments

### Testing
- All imports verified clean
- `test_create_ab_comparison` and `test_ab_comparison_defaults` pass
- Zero remaining `mid` references across all `.py`, `.sql`, `.js`, `.json` files