### PR TITLE
fix: keep drop zone visible after file is added (#493)

### DIFF
--- a/src/interfaces/chat_app/static/upload.css
+++ b/src/interfaces/chat_app/static/upload.css
@@ -238,6 +238,11 @@
   margin: 0;
 }
 
+/* Keep drop zone visible after files are added (override Dropzone's dz-started hide) */
+.dropzone.dz-started .dz-message {
+  display: block;
+}
+
 .dropzone-icon {
   color: var(--text-muted, #6e7681);
   margin-bottom: 16px;


### PR DESCRIPTION
Fixes #493

## Problem
When a file is added to the upload queue on `/upload`, the drop zone
(upload icon + "Drop files here or click to browse" text) disappears and
renders as a blank white area. It does not come back even after the file
is fully processed.  

Fix: 
<img width="1838" height="993" alt="Screenshot from 2026-03-06 02-01-40" src="https://github.com/user-attachments/assets/786b1a95-e5dd-47bb-99c2-950426f53e2c" />


## Root Cause
Dropzone.js adds the class `dz-started` to the form element as soon as
the first file is added. Its built-in stylesheet then hides `.dz-message`
via:

```css
.dropzone.dz-started .dz-message { display: none; }  
