### PR TITLE
fix: restore api keys tab and apply session key to pipeline default m…

### DIFF
--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -3548,8 +3548,28 @@ class FlaskAppWrapper(object):
 
         # Get API key from session if available
         session_api_key = None
-        if provider and 'provider_api_keys' in session:
-            session_api_key = session.get('provider_api_keys', {}).get(provider.lower())
+        session_provider_keys = session.get('provider_api_keys', {})
+        if provider and session_provider_keys:
+            session_api_key = session_provider_keys.get(provider.lower())
+        elif not provider and session_provider_keys:
+            # No explicit provider selected — check if the pipeline's active provider
+            # has a user-stored session key and inject it transparently so BYOK keys
+            # work even when the default pipeline model is being used (fixes #475).
+            try:
+                dyn = get_dynamic_config()
+                active_model = getattr(dyn, 'active_model', None) if dyn else None
+                if active_model and '/' in active_model:
+                    pipeline_provider, pipeline_model = active_model.split('/', 1)
+                else:
+                    chat_cfg = self.services_config.get('chat_app', {})
+                    pipeline_provider = chat_cfg.get('default_provider')
+                    pipeline_model = chat_cfg.get('default_model')
+                if pipeline_provider and pipeline_provider.lower() in session_provider_keys:
+                    provider = pipeline_provider.lower()
+                    model = model or pipeline_model
+                    session_api_key = session_provider_keys[provider]
+            except Exception:
+                pass  # Fall back to env key silently
 
         def _event_stream() -> Iterator[str]:
             padding = " " * 2048

--- a/src/interfaces/chat_app/templates/index.html
+++ b/src/interfaces/chat_app/templates/index.html
@@ -171,12 +171,12 @@
               </svg>
               <span>Models</span>
             </button>
-            <!-- <button class="settings-nav-item" data-section="api-keys" aria-selected="false">
+            <button class="settings-nav-item" data-section="api-keys" aria-selected="false">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
               </svg>
               <span>API Keys</span>
-            </button> -->
+            </button>
             <!-- <button class="settings-nav-item" data-section="advanced" aria-selected="false">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="3"></circle>
@@ -234,16 +234,16 @@
             </section>
             
             <!-- API Keys Section -->
-            <!-- <section class="settings-section" id="settings-api-keys" aria-labelledby="api-keys-heading" hidden>
+            <section class="settings-section" id="settings-api-keys" aria-labelledby="api-keys-heading" hidden>
               <h4 class="settings-section-title" id="api-keys-heading">API Keys</h4>
-              <p class="settings-description">Configure API keys for providers. Keys are stored securely in your browser session and are never logged or sent to our servers.</p>
+              <p class="settings-description">Override the deployment API key with your own. Keys are stored in your browser session only and cleared when you close the tab.</p>
               
               <div class="settings-group">
                 <div id="api-keys-container" class="api-keys-container">
                   <div class="api-key-loading">Loading...</div>
                 </div>
               </div>
-            </section> -->
+            </section>
             
             <!-- Advanced Section -->
             <!-- <section class="settings-section" id="settings-advanced" aria-labelledby="advanced-heading" hidden>


### PR DESCRIPTION
Fixes #475

## Problems
1. The API Keys tab in chat Settings was hidden (`<!-- commented out -->`) due to a known bug where the session key was ignored.

2. When a user saved a session API key but did NOT explicitly select a provider in the UI (i.e. used the pipeline default model), the session key was never looked up and the deployment admin key was always used instead, reverting any per-user override.

## Fix

**`index.html`** — Uncommented the API Keys nav button and section. Updated the description to clarify keys live in the browser session only.

**`app.py`** — In `get_chat_response_stream()`, extended the session key lookup to also cover the no-provider-selected case: when no explicit provider comes in from the frontend, the code now reads the pipeline's active model from `dynamic_config` (or falls back to `services.chat_app.default_provider`), checks if the user has a session key for that provider, and injects it — so the BYOK key is used transparently even with the default pipeline model.

## Tested
- Set a fake session key (`sk-fake999`) → sent a message → got an auth error from OpenAI confirming the session key was injected
- Cleared session key → chat worked normally with env key
- API Keys tab visible and functional in Settings modal

<img width="1838" height="993" alt="Screenshot from 2026-03-06 02-38-35" src="https://github.com/user-attachments/assets/13816a98-1301-4914-83b2-dbb2922fb631" />
