### PR TITLE
Add mcp_servers_config column to static_config table

### DIFF
--- a/src/utils/config_service.py
+++ b/src/utils/config_service.py
@@ -219,6 +219,7 @@ class ConfigService:
                     ADD COLUMN IF NOT EXISTS services_config JSONB DEFAULT '{}'::jsonb,
                     ADD COLUMN IF NOT EXISTS data_manager_config JSONB DEFAULT '{}'::jsonb,
                     ADD COLUMN IF NOT EXISTS archi_config JSONB DEFAULT '{}'::jsonb,
+                    ADD COLUMN IF NOT EXISTS mcp_servers_config JSONB DEFAULT '{}'::jsonb,
                     ADD COLUMN IF NOT EXISTS global_config JSONB DEFAULT '{}'::jsonb
                     """
                 )


### PR DESCRIPTION
Fix for issue reported by Maria
```
 Traceback (most recent call last):
File "/root/archi/src/bin/service_redmine.py", line 27, in <module>
redmine_config = get_services_config().get("redmine_mailbox", {})
File "/usr/local/lib/python3.10/site-packages/src/utils/config_access.py", line 38, in get_services_config
return get_static_config().services_config or {}
File "/usr/local/lib/python3.10/site-packages/src/utils/config_access.py", line 23, in get_static_config
cfg = _config_service().get_static_config()
File "/usr/local/lib/python3.10/site-packages/src/utils/config_service.py", line 285, in get_static_config
cursor.execute(
File "/usr/local/lib/python3.10/site-packages/psycopg2/extras.py", line 236, in execute
return super().execute(query, vars)
psycopg2.errors.UndefinedColumn: column "mcp_servers_config" does not exist
LINE 7: ...rvices_config, data_manager_config, archi_config, mcp_server...
```