### PR TITLE
LLM Model for redmine

### DIFF
--- a/src/bin/service_mailbox.py
+++ b/src/bin/service_mailbox.py
@@ -27,9 +27,9 @@ factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASS
 PostgresServiceFactory.set_instance(factory)
 
 mailbox_config = get_services_config().get("redmine_mailbox", {})
-redmine = redmine.Redmine('Redmine_Helpdesk_Mail') # this name tells redmine class to not initialize archi() class
+redmine_instance = redmine.Redmine('Redmine_Helpdesk_Mail') # this name tells redmine class to not initialize archi() class
 
 while True:
     mail = mailbox.Mailbox(user = user, password = password)
-    mail.process_messages(redmine)
+    mail.process_messages(redmine_instance)
     time.sleep(int(mailbox_config["mailbox_update_time"]))

--- a/src/bin/service_redmine.py
+++ b/src/bin/service_redmine.py
@@ -25,10 +25,10 @@ factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASS
 PostgresServiceFactory.set_instance(factory)
 
 redmine_config = get_services_config().get("redmine_mailbox", {})
-redmine = redmine.Redmine('Redmine_Helpdesk')
+redmine_instance = redmine.Redmine('Redmine_Helpdesk')
 
 while True:
-    redmine.load()
-    redmine.process_new_issues()
-    redmine.process_resolved_issues()
+    redmine_instance.load()
+    redmine_instance.process_new_issues()
+    redmine_instance.process_resolved_issues()
     time.sleep(int(redmine_config["redmine_update_time"]))

--- a/src/interfaces/redmine_mailer_integration/redmine.py
+++ b/src/interfaces/redmine_mailer_integration/redmine.py
@@ -42,8 +42,14 @@ class RedmineAIWrapper:
         self.redmine_config = self.services_config.get("redmine_mailbox", {})
         self.data_path = self.global_config["DATA_PATH"]
 
+        chat_app_config = self.services_config.get("chat_app", {})
+
         # agent
-        agent_class = self.redmine_config.get("agent_class") or self.redmine_config.get("pipeline", "CMSCompOpsAgent")
+        agent_class = (self.redmine_config.get("agent_class")
+                       or self.redmine_config.get("pipeline")
+                       or chat_app_config.get("agent_class")
+                       or chat_app_config.get("pipeline", "CMSCompOpsAgent"))
+
         agents_dir = Path(
             self.redmine_config.get("agents_dir")
             or self.services_config.get("chat_app", {}).get("agents_dir", "/root/archi/agents")
@@ -52,8 +58,10 @@ class RedmineAIWrapper:
             agent_spec = select_agent_spec(agents_dir)
         except AgentSpecError as exc:
             raise ValueError(f"Failed to load agent spec: {exc}") from exc
-        default_provider = self.redmine_config.get("default_provider")
-        default_model = self.redmine_config.get("default_model")
+        default_provider = (self.redmine_config.get("default_provider")
+                            or chat_app_config.get("default_provider"))
+        default_model = (self.redmine_config.get("default_model")
+                         or chat_app_config.get("default_model"))
         self.archi = archi(
             pipeline=agent_class,
             agent_spec=agent_spec,


### PR DESCRIPTION
redmine  reads default_provider and default_model from redmine_mailbox config, which are None since are were not sure.
Now 
If redmine_mailbox has its own model config → uses that
If not → automatically picks from chat_app 
No YAML duplication needed

this solve issue https://github.com/archi-physics/archi/issues/533#issuecomment-4120152478