### PR TITLE
Disable upload page UI

### DIFF
--- a/src/bin/service_data_manager.py
+++ b/src/bin/service_data_manager.py
@@ -181,7 +181,14 @@ def main() -> None:
     ingestion_thread = threading.Thread(target=run_initial_ingestion_async, name="ingestion-thread", daemon=True)
     ingestion_thread.start()
 
-    uploader = FlaskAppWrapper(app, post_update_hook=trigger_update, status_file=status_file)
+    enable_ui_uploads = data_manager_cfg.get("enable_ui_uploads", True)
+    logger.info(f"Data Manager: enable_ui_uploads = {enable_ui_uploads}")
+    uploader = FlaskAppWrapper(
+        app,
+        post_update_hook=trigger_update,
+        status_file=status_file,
+        enable_ui_uploads=enable_ui_uploads
+    )
     def get_ingestion_status():
         with lock:
             return jsonify(dict(ingestion_status))

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -88,7 +88,7 @@ services:
     num_responses_until_feedback: {{ services.chat_app.num_responses_until_feedback | default(3, true) }}
     include_copy_button: {{ services.chat_app.include_copy_button | default(false, true) }}
     flask_debug_mode: {{ services.chat_app.flask_debug_mode | default(true, false) }}
-    enable_ui_uploads: {{ services.data_manager.enable_ui_uploads | default(true, false) }}
+    enable_ui_uploads: {{ services.chat_app.enable_ui_uploads | default(true, false) }}
     auth:
       enabled: {{ services.chat_app.auth.enabled | default(false, true) }}
       sso:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -88,6 +88,7 @@ services:
     num_responses_until_feedback: {{ services.chat_app.num_responses_until_feedback | default(3, true) }}
     include_copy_button: {{ services.chat_app.include_copy_button | default(false, true) }}
     flask_debug_mode: {{ services.chat_app.flask_debug_mode | default(true, false) }}
+    enable_ui_uploads: {{ services.data_manager.enable_ui_uploads | default(true, false) }}
     auth:
       enabled: {{ services.chat_app.auth.enabled | default(false, true) }}
       sso:
@@ -162,6 +163,7 @@ services:
     template_folder: "{{ services.data_manager.template_folder | default('/root/archi/src/interfaces/chat_app/templates', true) }}"
     static_folder: "{{ services.data_manager.static_folder | default('/root/archi/src/interfaces/chat_app/static', true) }}"
     flask_debug_mode: {{ services.data_manager.flask_debug_mode | default(false, true) }}
+    enable_ui_uploads: {{ services.data_manager.enable_ui_uploads | default(true, false) }}
   grader_app:
     provider: {{ services.grader_app.provider }}
     model: {{ services.grader_app.model }}

--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -2429,6 +2429,7 @@ class FlaskAppWrapper(object):
         self.global_config = self.config["global"]
         self.services_config = self.config["services"]
         self.chat_app_config = self.config["services"]["chat_app"]
+        self.enable_ui_uploads = self.chat_app_config.get('enable_ui_uploads', True)
         self.data_path = self.global_config["DATA_PATH"]
         self.salt = read_secret("UPLOADER_SALT")
         secret_key = read_secret("FLASK_UPLOADER_APP_SECRET_KEY")
@@ -2584,22 +2585,29 @@ class FlaskAppWrapper(object):
         self.add_endpoint('/api/data/bulk-disable', 'bulk_disable_documents', self.require_perm(Permission.Documents.SELECT)(self.bulk_disable_documents), methods=["POST"])
         self.add_endpoint('/api/data/stats', 'get_data_stats', self.require_perm(Permission.Documents.VIEW)(self.get_data_stats), methods=["GET"])
 
-        # Data uploader endpoints
+        # Data uploader endpoints - conditionally register
         logger.info("Adding data uploader API endpoints")
-        self.add_endpoint('/upload', 'upload_page', self.require_perm(Permission.Upload.PAGE)(self.upload_page))
-        self.add_endpoint('/api/upload/file', 'upload_file', self.require_perm(Permission.Upload.FILE)(self.upload_file), methods=["POST"])
-        self.add_endpoint('/api/upload/url', 'upload_url', self.require_perm(Permission.Upload.URL)(self.upload_url), methods=["POST"])
-        self.add_endpoint('/api/upload/git', 'upload_git', self.require_perm(Permission.Upload.GIT)(self.upload_git), methods=["POST", "DELETE"])
-        self.add_endpoint('/api/upload/git/refresh', 'refresh_git', self.require_perm(Permission.Upload.GIT)(self.refresh_git), methods=["POST"])
-        self.add_endpoint('/api/upload/jira', 'upload_jira', self.require_perm(Permission.Upload.JIRA)(self.upload_jira), methods=["POST"])
-        self.add_endpoint('/api/upload/embed', 'trigger_embedding', self.require_perm(Permission.Upload.EMBED)(self.trigger_embedding), methods=["POST"])
-        self.add_endpoint('/api/upload/status', 'get_embedding_status', self.require_perm(Permission.Upload.EMBED)(self.get_embedding_status), methods=["GET"])
-        self.add_endpoint('/api/upload/documents', 'list_upload_documents', self.require_perm(Permission.Documents.VIEW)(self.list_upload_documents), methods=["GET"])
-        self.add_endpoint('/api/upload/documents/grouped', 'list_upload_documents_grouped', self.require_perm(Permission.Documents.VIEW)(self.list_upload_documents_grouped), methods=["GET"])
-        self.add_endpoint('/api/upload/documents/<document_hash>/retry', 'retry_document', self.require_perm(Permission.Documents.SELECT)(self.retry_document), methods=["POST"])
-        self.add_endpoint('/api/upload/documents/retry-all-failed', 'retry_all_failed', self.require_perm(Permission.Documents.SELECT)(self.retry_all_failed), methods=["POST"])
-        self.add_endpoint('/api/sources/git', 'list_git_sources', self.require_perm(Permission.Sources.VIEW)(self.list_git_sources), methods=["GET"])
-        self.add_endpoint('/api/sources/jira', 'list_jira_sources', self.require_perm(Permission.Sources.VIEW)(self.list_jira_sources), methods=["GET", "DELETE"])
+        if self.enable_ui_uploads:
+            logger.info("Adding data uploader API endpoints")
+            self.add_endpoint('/upload', 'upload_page', self.require_perm(Permission.Upload.PAGE)(self.upload_page))
+            self.add_endpoint('/api/upload/file', 'upload_file', self.require_perm(Permission.Upload.FILE)(self.upload_file), methods=["POST"])
+            self.add_endpoint('/api/upload/url', 'upload_url', self.require_perm(Permission.Upload.URL)(self.upload_url), methods=["POST"])
+            self.add_endpoint('/api/upload/git', 'upload_git', self.require_perm(Permission.Upload.GIT)(self.upload_git), methods=["POST", "DELETE"])
+            self.add_endpoint('/api/upload/git/refresh', 'refresh_git', self.require_perm(Permission.Upload.GIT)(self.refresh_git), methods=["POST"])
+            self.add_endpoint('/api/upload/jira', 'upload_jira', self.require_perm(Permission.Upload.JIRA)(self.upload_jira), methods=["POST"])
+            self.add_endpoint('/api/upload/embed', 'trigger_embedding', self.require_perm(Permission.Upload.EMBED)(self.trigger_embedding), methods=["POST"])
+            self.add_endpoint('/api/upload/status', 'get_embedding_status', self.require_perm(Permission.Upload.EMBED)(self.get_embedding_status), methods=["GET"])
+            self.add_endpoint('/api/upload/documents', 'list_upload_documents', self.require_perm(Permission.Documents.VIEW)(self.list_upload_documents), methods=["GET"])
+            self.add_endpoint('/api/upload/documents/grouped', 'list_upload_documents_grouped', self.require_perm(Permission.Documents.VIEW)(self.list_upload_documents_grouped), methods=["GET"])
+            self.add_endpoint('/api/upload/documents/<document_hash>/retry', 'retry_document', self.require_perm(Permission.Documents.SELECT)(self.retry_document), methods=["POST"])
+            self.add_endpoint('/api/upload/documents/retry-all-failed', 'retry_all_failed', self.require_perm(Permission.Documents.SELECT)(self.retry_all_failed), methods=["POST"])
+            self.add_endpoint('/api/sources/git', 'list_git_sources', self.require_perm(Permission.Sources.VIEW)(self.list_git_sources), methods=["GET"])
+            self.add_endpoint('/api/sources/jira', 'list_jira_sources', self.require_perm(Permission.Sources.VIEW)(self.list_jira_sources), methods=["GET", "DELETE"])
+        else:
+            logger.info("UI uploads disabled in chat_app config")
+            # Data uploader endpoints
+
+        # Always keep source schedule endpoints (backend management)
         self.add_endpoint('/api/sources/schedules', 'source_schedules', self.require_perm(Permission.Sources.SELECT)(self.source_schedules_dispatch), methods=["GET", "PUT"])
 
         # Database viewer endpoints (admin only)

--- a/src/interfaces/uploader_app/app.py
+++ b/src/interfaces/uploader_app/app.py
@@ -36,10 +36,13 @@ class FlaskAppWrapper:
         *,
         post_update_hook: Optional[Callable[[], None]] = None,
         status_file: Optional[Path] = None,
+        enable_ui_uploads: bool = True,
     ) -> None:
         self.app = app
         self.config = get_full_config()
         self.global_config = self.config["global"]
+        self.enable_ui_uploads = enable_ui_uploads
+        logger.info(f"UI uploads setting: {self.enable_ui_uploads}")
         self.services_config = self.config["services"]
 
         self.data_path = self.global_config["DATA_PATH"]
@@ -86,17 +89,25 @@ class FlaskAppWrapper:
 
         protected = self.require_admin
         self.add_endpoint("/api/health", "health", self.health, methods=["GET"])
-        self.add_endpoint("/document_index/upload", "upload", protected(self.upload), methods=["POST"])
+
+        # CONDITIONAL: Only register UI upload endpoints if enabled
+        if self.enable_ui_uploads:
+            logger.info("UI uploads enabled")
+            self.add_endpoint("/document_index/upload", "upload", protected(self.upload), methods=["POST"])
+            self.add_endpoint("/document_index/upload_url", "upload_url", protected(self.upload_url), methods=["POST"])
+            self.add_endpoint("/document_index/add_git_repo", "add_git_repo", protected(self.add_git_repo), methods=["POST"])
+            self.add_endpoint("/document_index/add_jira_project", "add_jira_project", protected(self.add_jira_project), methods=["POST"])
+        else:
+            logger.info("UI uploads disabled - only backend ingestion available")
+
+        # ALWAYS register these endpoints
         self.add_endpoint("/document_index/delete/<file_hash>", "delete", protected(self.delete))
         self.add_endpoint(
             "/document_index/delete_source/<source_type>",
             "delete_source",
             protected(self.delete_source),
         )
-        self.add_endpoint("/document_index/upload_url", "upload_url", protected(self.upload_url), methods=["POST"])
-        self.add_endpoint("/document_index/add_git_repo", "add_git_repo", protected(self.add_git_repo), methods=["POST"])
         self.add_endpoint("/document_index/remove_git_repo", "remove_git_repo", protected(self.remove_git_repo), methods=["POST"])
-        self.add_endpoint("/document_index/add_jira_project", "add_jira_project", protected(self.add_jira_project), methods=["POST"])
         self.add_endpoint("/document_index/update_schedule", "update_schedule", protected(self.update_schedule), methods=["POST"])
         self.add_endpoint("/document_index/load_document/<path:file_hash>", "load_document", protected(self.load_document))
         # API endpoints for remote catalog access
@@ -169,6 +180,10 @@ class FlaskAppWrapper:
         return jsonify({"status": "OK"}), 200
 
     def add_git_repo(self):
+        if not self.enable_ui_uploads:
+            logger.error("Git repo add attempted but UI uploads are disabled")
+            return jsonify({"error": "uploads_disabled", "message": "Git uploads are disabled"}), 403
+
         repo_url = request.form.get("repo_url") or ""
         if not repo_url.strip():
             return jsonify({"error": "missing_repo_url"}), 400
@@ -212,6 +227,10 @@ class FlaskAppWrapper:
             return jsonify({"error": "delete_failed", "detail": str(exc)}), 500
 
     def add_jira_project(self):
+        if not self.enable_ui_uploads:
+            logger.error("Jira project add attempted but UI uploads are disabled")
+            return jsonify({"error": "uploads_disabled", "message": "Jira uploads are disabled"}), 403
+
         project_key = request.form.get("project_key") or ""
         if not project_key.strip():
             return jsonify({"error": "missing_project_key"}), 400
@@ -231,6 +250,10 @@ class FlaskAppWrapper:
 
     def upload(self):
         """Handle file uploads from the UI and persist them via the local files manager."""
+        if not self.enable_ui_uploads:
+            logger.error("Upload attempted but UI uploads are disabled")
+            return jsonify({"error": "uploads_disabled", "message": "File uploads are disabled"}), 403
+
         upload = request.files.get("file")
         if not upload:
             return jsonify({"error": "missing_file"}), 400
@@ -268,6 +291,10 @@ class FlaskAppWrapper:
         """
         Use the ScraperManager to collect and persist a single URL provided via form data.
         """
+        if not self.enable_ui_uploads:
+            logger.error("URL upload attempted but UI uploads are disabled")
+            return jsonify({"error": "uploads_disabled", "message": "URL uploads are disabled"}), 403
+
         url = request.form.get("url")
         depth_raw = request.form.get("depth")
         depth: Optional[int] = None


### PR DESCRIPTION
In the context of submit the chatbot is provided to any users of the analysis facility.
Only the experts should be able to upload material, while at the moment  anyone can add some (including spam).

in this PR I add the enable_ui_uploads parameter  in the .yaml so that the upload from the ui is configurable.

```
services:
  chat_app:
    enable_ui_uploads: false  # Disable upload page UI
  data_manager:
    enable_ui_uploads: false
```