### PR TITLE
feat(data-manager): add Indico scraper integration

### DIFF
--- a/docs/docs/data_sources.md
+++ b/docs/docs/data_sources.md
@@ -113,6 +113,40 @@ Once enabled in config, deploy normally with `archi create --config <config.yaml
 
 ---
 
+## Indico
+
+Ingest events, contributions (talks) and slide materials from an [Indico](https://getindico.io/) instance. Slides in PDF/PPTX/PPT/ODP format are converted to Markdown via [MarkItDown](https://github.com/microsoft/markitdown).
+
+### Configuration
+
+```yaml
+data_manager:
+  sources:
+    indico:
+      enabled: true
+      base_url: https://indico.cern.ch
+      use_sso: false       # set true for SSO-protected events
+      slide_conversion:
+        enabled: true
+        formats: [pdf, pptx, ppt, odp]
+```
+
+Add event URLs to your link lists. URLs with `indico` in the hostname and `/event/` in the path are auto-detected. For Indico instances without `indico` in the hostname, use the explicit `indico-` prefix:
+
+```
+https://indico.cern.ch/event/1408515/
+https://indico.stfc.ac.uk/event/1825/
+indico-https://events.example.org/event/42/
+```
+
+For each event the scraper produces Markdown resources for the event metadata, each contribution (talk), and each slide deck. Multi-day events can be restricted with day-filtering options (`max_days`, `only_first_day`, `days`, `date_range`) — see `src/cli/templates/base-config.yaml` for the full set.
+
+For SSO-protected events, set `use_sso: true` and configure the Selenium-based collector as for [SSO-Protected Links](#sso-protected-links). The same `SSO_USERNAME` / `SSO_PASSWORD` secrets are used.
+
+Once enabled in config, deploy normally with `archi create --config <config.yaml> --services <...>`.
+
+---
+
 ## JIRA
 
 Fetch issues and comments from specified JIRA projects using the `JiraClient` class.

--- a/examples/agents/indico-assistant.md
+++ b/examples/agents/indico-assistant.md
@@ -1,0 +1,24 @@
+---
+name: Indico Assistant
+tools:
+  - search_vectorstore_hybrid
+  - search_metadata_index
+  - list_metadata_schema
+  - fetch_catalog_document
+---
+
+You are an assistant answering questions about events, talks, speakers, and
+slide materials ingested from Indico.
+
+**Before answering any factual question you MUST call `search_vectorstore_hybrid`.**
+Do not answer from your own knowledge — the user is asking about ingested data.
+
+Build search queries from the most distinctive terms in the user's question
+(speaker last name, event name, topic, date). Use 3-8 keywords.
+
+After retrieving, cite the speaker name, contribution title, and event from the
+retrieved context. Include the contribution URL when available. If retrieval
+returns nothing relevant, say so — do not fabricate.
+
+For broad listing questions ("what talks were given at X?"), use
+`search_metadata_index` with `event_title:<name>` first.

--- a/examples/deployments/basic-agent/indico_example.list
+++ b/examples/deployments/basic-agent/indico_example.list
@@ -1,0 +1,8 @@
+# Example Indico URLs for Archi
+# URLs with "indico" in the hostname and /event/ in the path are auto-detected.
+# For Indico instances without "indico" in the hostname, use the "indico-" prefix.
+
+# FCC Week 2025 (public, with slides)
+https://indico.cern.ch/event/1408515/
+
+# For protected events, ensure SSO_USERNAME and SSO_PASSWORD are set in secrets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "pandas==2.3.2",
     "isort==6.0.1",
     "pre-commit>=4",
-    "psycopg2-binary==2.9.10"
+    "psycopg2-binary==2.9.10",
+    "markitdown[pdf,pptx]>=0.1.0"
 ]
 
 [project.scripts]

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -86,3 +86,4 @@ aiohttp==3.9.5
 nltk==3.9.1
 sentence-transformers==5.1.2
 rank_bm25==0.2.2
+markitdown[pdf,pptx]>=0.1.0

--- a/src/cli/source_registry.py
+++ b/src/cli/source_registry.py
@@ -74,6 +74,13 @@ class SourceRegistry:
                 ],
             )
         )
+        self.register(
+            SourceDefinition(
+                name="indico",
+                description="Indico event and meeting scraping",
+                depends_on=["links"],
+            )
+        )
 
     def register(self, source_def: SourceDefinition) -> None:
         self._sources[source_def.name] = source_def

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -222,6 +222,40 @@ data_manager:
       enabled: {{ data_manager.sources.sso.enabled | default(true, true) }}
       visible: {{ data_manager.sources.sso.visible | default(true, true) }}
       schedule: '{{ data_manager.sources.sso.schedule | default("", true) }}'
+    indico:
+      enabled: {{ data_manager.sources.indico.enabled | default(false, true) }}
+      visible: {{ data_manager.sources.indico.visible | default(true, true) }}
+      schedule: '{{ data_manager.sources.indico.schedule | default("", true) }}'
+      base_url: {{ data_manager.sources.indico.base_url | default('https://indico.cern.ch', true) }}
+      use_sso: {{ data_manager.sources.indico.use_sso | default(true) }}
+      # Day filtering (all optional - if none set, scrapes all days)
+      {%- if data_manager.sources.indico.max_days is defined %}
+      max_days: {{ data_manager.sources.indico.max_days }}
+      {%- endif %}
+      {%- if data_manager.sources.indico.only_first_day is defined %}
+      only_first_day: {{ data_manager.sources.indico.only_first_day }}
+      {%- endif %}
+      {%- if data_manager.sources.indico.days is defined %}
+      days: {{ data_manager.sources.indico.days | tojson }}
+      {%- endif %}
+      {%- if data_manager.sources.indico.date_range is defined %}
+      date_range: {{ data_manager.sources.indico.date_range | tojson }}
+      {%- endif %}
+      sso_kwargs:
+        headless: {{ data_manager.sources.indico.sso_kwargs.headless | default(true, true) }}
+        site_type: {{ data_manager.sources.indico.sso_kwargs.site_type | default('generic', true) }}
+      slide_conversion:
+        enabled: {{ data_manager.sources.indico.slide_conversion.enabled | default(true) }}
+        store_originals: {{ data_manager.sources.indico.slide_conversion.store_originals | default(false, true) }}
+        formats:
+          {%- set indico_formats = data_manager.sources.indico.slide_conversion.formats | default(['pdf', 'pptx', 'ppt', 'odp'], true) %}
+          {%- for format in indico_formats %}
+          - {{ format }}
+          {%- endfor %}
+        llm_enabled: {{ data_manager.sources.indico.slide_conversion.llm_enabled | default(false, true) }}
+        llm_model: {{ data_manager.sources.indico.slide_conversion.llm_model | default('', true) }}
+      plot_extraction:
+        enabled: {{ data_manager.sources.indico.plot_extraction.enabled | default(false, true) }}
     jira:
       enabled: {{ data_manager.sources.jira.enabled | default(true, true) }}
       url: {{ data_manager.sources.jira.url | default('', true) }}

--- a/src/data_manager/collectors/scrapers/integrations/indico_scraper.py
+++ b/src/data_manager/collectors/scrapers/integrations/indico_scraper.py
@@ -1,0 +1,1287 @@
+"""Scraper integration for CERN Indico events and materials."""
+
+import re
+import time
+from datetime import date as date_cls
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+from src.data_manager.collectors.scrapers.scraped_resource import ScrapedResource
+from src.data_manager.collectors.utils.slide_converter import SlideConverter
+from src.utils.config_access import get_global_config
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from src.data_manager.collectors.scrapers.scraper_manager import ScraperManager
+
+
+class IndicoScraper:
+    """Scraper integration for CERN Indico events and materials.
+
+    Uses Indico REST API to fetch event metadata and CERNSSOScraper
+    for authentication. Downloads attachments and converts slides to
+    markdown using MarkItDown (no original file storage).
+    """
+
+    def __init__(
+        self, manager: "ScraperManager", indico_config: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Initialize the Indico scraper.
+
+        Args:
+            manager: Parent ScraperManager instance
+            indico_config: Configuration dictionary for Indico scraping
+        """
+        self.manager = manager
+        self.config = indico_config or {}
+
+        global_config = get_global_config()
+        self.data_path = global_config["DATA_PATH"]
+
+        # Configuration
+        self.base_url = self.config.get("base_url", "https://indico.cern.ch")
+        self.use_sso = self.config.get("use_sso", True)
+
+        # Slide conversion config
+        slide_config = self.config.get("slide_conversion", {})
+        self.conversion_enabled = slide_config.get("enabled", True)
+        self.supported_formats = set(
+            slide_config.get("formats", ["pdf", "pptx", "ppt", "odp"])
+        )
+
+        # Initialize slide converter
+        llm_client = slide_config.get("llm_client")
+        llm_model = slide_config.get("llm_model")
+        self.slide_converter = SlideConverter(
+            llm_client=llm_client, llm_model=llm_model
+        )
+
+        # SSO scraper for authentication
+        self.sso_scraper = None
+        if self.use_sso:
+            try:
+                from src.data_manager.collectors.scrapers.integrations.sso_scraper import (
+                    CERNSSOScraper,
+                )
+
+                sso_kwargs = self.config.get("sso_kwargs", {"headless": True})
+                self.sso_scraper = CERNSSOScraper(**sso_kwargs)
+                logger.info("Initialized CERNSSOScraper for Indico authentication")
+            except Exception as e:
+                logger.warning(f"Failed to initialize SSO scraper: {e}")
+                self.sso_scraper = None
+
+    def collect(self, event_urls: List[str]) -> List[ScrapedResource]:
+        """Collect events, contributions, and materials from Indico URLs.
+
+        Args:
+            event_urls: List of Indico event or category URLs
+
+        Returns:
+            List of ScrapedResource objects with converted markdown content
+        """
+        if not event_urls:
+            return []
+
+        resources: List[ScrapedResource] = []
+        authenticated_session = None
+
+        try:
+            for url in event_urls:
+                try:
+                    if "/event/" in url:
+                        event_id = self._extract_event_id(url)
+                        if event_id:
+                            # Auto-detect if authentication is needed
+                            needs_auth = self._check_event_requires_auth(event_id)
+
+                            if needs_auth and self.use_sso:
+                                # Set up authenticated session (reuse if already created)
+                                if authenticated_session is None:
+                                    authenticated_session = (
+                                        self._setup_authenticated_session(url)
+                                    )
+                                session = authenticated_session
+                            elif needs_auth and not self.use_sso:
+                                logger.warning(
+                                    f"Event {event_id} requires authentication but use_sso=False; skipping"
+                                )
+                                continue
+                            else:
+                                # Public event - use unauthenticated session
+                                session = requests.Session()
+
+                            resources.extend(self._collect_event(event_id, session))
+                    elif "/category/" in url:
+                        category_id = self._extract_category_id(url)
+                        if category_id:
+                            # Categories often require auth, use authenticated session if available
+                            if self.use_sso and authenticated_session is None:
+                                authenticated_session = (
+                                    self._setup_authenticated_session(url)
+                                )
+                            session = (
+                                authenticated_session
+                                if authenticated_session
+                                else requests.Session()
+                            )
+                            resources.extend(
+                                self._collect_category(category_id, session)
+                            )
+                    else:
+                        logger.warning(f"Unrecognized Indico URL format: {url}")
+                except Exception as e:
+                    logger.error(f"Error collecting from {url}: {e}")
+
+        finally:
+            # Clean up SSO scraper
+            if self.sso_scraper:
+                self.sso_scraper.close()
+
+        logger.info(f"Indico scraping completed. Collected {len(resources)} resources.")
+        return resources
+
+    def _compute_allowed_contribution_dates(
+        self, event_data: Dict[str, Any]
+    ) -> Optional[set[str]]:
+        """
+        Compute allowed contribution dates (YYYY-MM-DD) based on configuration.
+
+        Supported config keys under `data_manager.sources.indico`:
+          - days: [YYYY-MM-DD, ...] (explicit allow-list)
+          - date_range: {from: YYYY-MM-DD, to: YYYY-MM-DD} (inclusive)
+          - only_first_day: true (alias: first_day_only)
+          - day_limit: N (alias: max_days) -> allow first N days starting at event startDate
+        """
+        # Highest precedence: explicit allow-list
+        days = self.config.get("days")
+        if isinstance(days, list) and days:
+            return {str(d).strip() for d in days if str(d).strip()}
+
+        # Next: inclusive date range
+        date_range = self.config.get("date_range")
+        if isinstance(date_range, dict):
+            start_s = str(date_range.get("from", "")).strip()
+            end_s = str(date_range.get("to", "")).strip()
+            if start_s and end_s:
+                try:
+                    start_d = date_cls.fromisoformat(start_s)
+                    end_d = date_cls.fromisoformat(end_s)
+                    if end_d < start_d:
+                        start_d, end_d = end_d, start_d
+                    out: set[str] = set()
+                    cur = start_d
+                    while cur <= end_d:
+                        out.add(cur.isoformat())
+                        cur += timedelta(days=1)
+                    return out
+                except Exception as e:
+                    logger.warning(
+                        f"Invalid indico.date_range; expected YYYY-MM-DD: {e}"
+                    )
+
+        # Next: first day only
+        only_first_day = bool(
+            self.config.get("only_first_day") or self.config.get("first_day_only")
+        )
+        start_date_s = str((event_data.get("startDate") or {}).get("date", "")).strip()
+        if only_first_day and start_date_s:
+            return {start_date_s}
+
+        # Next: first N days
+        day_limit = self.config.get("day_limit", self.config.get("max_days"))
+        if isinstance(day_limit, int) and day_limit > 0 and start_date_s:
+            try:
+                start_d = date_cls.fromisoformat(start_date_s)
+                return {
+                    (start_d + timedelta(days=i)).isoformat() for i in range(day_limit)
+                }
+            except Exception as e:
+                logger.warning(
+                    f"Invalid indico day_limit/max_days start date '{start_date_s}': {e}"
+                )
+
+        return None
+
+    def _check_event_requires_auth(self, event_id: str) -> bool:
+        """Check if an event requires authentication by trying an unauthenticated request.
+
+        Indico returns empty results for protected events rather than 401/403,
+        so we check for actual content in the response.
+
+        Args:
+            event_id: Event ID to check
+
+        Returns:
+            True if authentication is required, False if public
+        """
+        test_url = f"{self.base_url}/export/event/{event_id}.json"
+        try:
+            response = requests.get(test_url, timeout=10, allow_redirects=False)
+
+            # Public events return 200 with JSON data containing results
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    results = data.get("results", [])
+
+                    # Protected events return {"results": []} - empty array
+                    # Public events return {"results": [{event_data}]}
+                    if isinstance(results, list) and len(results) > 0:
+                        # Check the first result has actual content
+                        first_result = results[0]
+                        if first_result.get("title") or first_result.get("id"):
+                            logger.info(
+                                f"Event {event_id} is public (no auth required)"
+                            )
+                            return False
+
+                    # Empty results = protected event
+                    if data.get("count", 1) == 0 or not results:
+                        logger.info(
+                            f"Event {event_id} requires authentication (empty results)"
+                        )
+                        return True
+
+                except ValueError:
+                    pass  # Not JSON, probably needs auth
+
+            # Check for auth redirects or forbidden responses
+            if response.status_code in [401, 403]:
+                logger.info(
+                    f"Event {event_id} requires authentication (got {response.status_code})"
+                )
+                return True
+
+            # Redirect to login page indicates auth required
+            if response.status_code in [301, 302, 303, 307, 308]:
+                location = response.headers.get("Location", "")
+                if (
+                    "login" in location.lower()
+                    or "sso" in location.lower()
+                    or "auth" in location.lower()
+                ):
+                    logger.info(
+                        f"Event {event_id} requires authentication (redirect to login)"
+                    )
+                    return True
+
+            # If we get here with non-200, assume auth might be needed
+            if response.status_code != 200:
+                logger.info(
+                    f"Event {event_id} status {response.status_code}, assuming auth required"
+                )
+                return True
+
+            # Default: assume auth required for safety
+            logger.info(f"Event {event_id} - unclear status, assuming auth required")
+            return True
+
+        except Exception as e:
+            logger.warning(
+                f"Error checking auth for event {event_id}: {e}, assuming auth required"
+            )
+            return True
+
+    def _setup_authenticated_session(self, initial_url: str) -> requests.Session:
+        """Set up an authenticated session using CERNSSOScraper.
+
+        Args:
+            initial_url: URL to trigger authentication
+
+        Returns:
+            Authenticated requests.Session
+        """
+        session = requests.Session()
+
+        if self.sso_scraper:
+            try:
+                logger.info("Setting up authenticated session with CERN SSO")
+                self.sso_scraper.setup_driver()
+
+                # Authenticate and get cookies
+                cookies = self.sso_scraper.authenticate(initial_url)
+
+                if cookies:
+                    for cookie in cookies:
+                        # Transfer all cookie attributes including domain
+                        # Strip leading dot from domain if present (requests handles this)
+                        domain = cookie.get("domain", "")
+                        if domain.startswith("."):
+                            domain = domain[1:]  # Remove leading dot
+
+                        session.cookies.set(
+                            cookie["name"],
+                            cookie["value"],
+                            domain=domain,
+                            path=cookie.get("path", "/"),
+                            secure=cookie.get("secure", False),
+                        )
+                        logger.debug(
+                            f"Set cookie: {cookie['name']} for domain {domain}"
+                        )
+                    logger.info(
+                        f"Successfully authenticated with CERN SSO ({len(cookies)} cookies)"
+                    )
+                else:
+                    logger.warning("Authentication did not return cookies")
+
+            except Exception as e:
+                logger.error(f"Error during SSO authentication: {e}")
+
+        return session
+
+    def _collect_event(
+        self, event_id: str, session: requests.Session
+    ) -> List[ScrapedResource]:
+        """Collect a single event with its contributions and materials.
+
+        Args:
+            event_id: Indico event ID
+            session: Authenticated session
+
+        Returns:
+            List of ScrapedResource objects
+        """
+        resources: List[ScrapedResource] = []
+
+        try:
+            # Fetch event metadata
+            event_data = self._fetch_event_metadata(event_id, session)
+            if not event_data:
+                return resources
+
+            # Create resource for event metadata
+            event_resource = self._create_event_resource(event_id, event_data)
+            if event_resource:
+                resources.append(event_resource)
+
+            # Fetch contributions (talks)
+            contributions = self._fetch_contributions(event_id, session)
+
+            allowed_dates = self._compute_allowed_contribution_dates(event_data)
+            if allowed_dates:
+                before = len(contributions)
+                contributions = [
+                    c
+                    for c in contributions
+                    if str((c.get("startDate") or {}).get("date", "")).strip()
+                    in allowed_dates
+                ]
+                logger.info(
+                    "Filtering contributions by date for event %s: %s (kept %s/%s)",
+                    event_id,
+                    sorted(allowed_dates),
+                    len(contributions),
+                    before,
+                )
+
+            event_title = (event_data or {}).get("title", "")
+            event_start = (event_data or {}).get("startDate") or {}
+            event_date = (
+                event_start.get("date", "") if isinstance(event_start, dict) else ""
+            )
+
+            for contribution in contributions:
+                # Download and convert materials first
+                material_resources = self._collect_materials(
+                    event_id,
+                    contribution,
+                    session,
+                    event_title=event_title,
+                    event_date=event_date,
+                )
+                # Only create standalone contribution metadata when there are no materials:
+                # otherwise we duplicate and show a wrong URL (API id vs URL contribution id)
+                if not material_resources:
+                    contrib_resource = self._create_contribution_resource(
+                        event_id,
+                        contribution,
+                        event_title=event_title,
+                        event_date=event_date,
+                    )
+                    if contrib_resource:
+                        resources.append(contrib_resource)
+                resources.extend(material_resources)
+
+        except Exception as e:
+            logger.error(f"Error collecting event {event_id}: {e}")
+
+        return resources
+
+    def _collect_category(
+        self, category_id: str, session: requests.Session
+    ) -> List[ScrapedResource]:
+        """Collect events from a category.
+
+        For now, only collects events directly in the category (no recursion).
+
+        Args:
+            category_id: Indico category ID
+            session: Authenticated session
+
+        Returns:
+            List of ScrapedResource objects
+        """
+        resources: List[ScrapedResource] = []
+
+        try:
+            # Fetch category metadata to get list of events
+            category_url = f"{self.base_url}/export/category/{category_id}.json"
+            response = session.get(category_url, timeout=30)
+            response.raise_for_status()
+            category_data = response.json()
+
+            events = category_data.get("results", [])
+            logger.info(f"Found {len(events)} events in category {category_id}")
+
+            for event in events:
+                event_id = str(event.get("id", ""))
+                if event_id:
+                    resources.extend(self._collect_event(event_id, session))
+
+        except Exception as e:
+            logger.error(f"Error collecting category {category_id}: {e}")
+
+        return resources
+
+    def _fetch_event_metadata(
+        self, event_id: str, session: requests.Session
+    ) -> Optional[Dict]:
+        """Fetch event metadata from Indico API.
+
+        Args:
+            event_id: Event ID
+            session: Authenticated session
+
+        Returns:
+            Event data dictionary or None
+        """
+        try:
+            url = f"{self.base_url}/export/event/{event_id}.json"
+            logger.info(f"Fetching event metadata: {url}")
+
+            response = session.get(url, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            # Indico wraps the event in a 'results' list
+            if isinstance(data, dict) and "results" in data:
+                results = data["results"]
+                if results and len(results) > 0:
+                    return results[0]
+
+            return data
+
+        except Exception as e:
+            logger.error(f"Error fetching event {event_id}: {e}")
+            return None
+
+    def _fetch_contributions(
+        self, event_id: str, session: requests.Session
+    ) -> List[Dict]:
+        """Fetch all contributions (talks) for an event.
+
+        First tries the JSON API. If that returns 0 contributions,
+        falls back to scraping the timetable HTML view.
+
+        Args:
+            event_id: Event ID
+            session: Authenticated session
+
+        Returns:
+            List of contribution dictionaries
+        """
+        # Try the standard API first
+        contributions = self._fetch_contributions_from_api(event_id, session)
+
+        # Fallback to timetable scraping if API returns nothing
+        if not contributions:
+            logger.info(
+                f"No contributions from API for event {event_id}, trying timetable view..."
+            )
+            contributions = self._fetch_contributions_from_timetable(event_id, session)
+
+        return contributions
+
+    def _fetch_contributions_from_api(
+        self, event_id: str, session: requests.Session
+    ) -> List[Dict]:
+        """Fetch contributions from the JSON API endpoint."""
+        try:
+            url = f"{self.base_url}/export/event/{event_id}.json?detail=contributions"
+            logger.info(f"Fetching contributions: {url}")
+
+            response = session.get(url, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            results = data.get("results", [])
+            if results and isinstance(results, list) and len(results) > 0:
+                contributions = results[0].get("contributions", [])
+            else:
+                contributions = []
+            logger.info(
+                f"Found {len(contributions)} contributions from API for event {event_id}"
+            )
+
+            return contributions
+
+        except Exception as e:
+            logger.error(
+                f"Error fetching contributions from API for event {event_id}: {e}"
+            )
+            return []
+
+    def _fetch_contributions_from_timetable(
+        self, event_id: str, session: requests.Session
+    ) -> List[Dict]:
+        """Fallback: scrape contributions from the timetable HTML view.
+
+        Some Indico events structure content in timetable sessions rather than
+        direct contributions. This scrapes the timetable page to extract them.
+        Uses Selenium if available for authenticated access.
+        """
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            logger.warning("BeautifulSoup not available; cannot scrape timetable HTML")
+            return []
+
+        contributions = []
+        html_content = None
+
+        # Try Selenium first if SSO scraper is available (better for authenticated pages)
+        if self.sso_scraper and self.sso_scraper.driver:
+            timetable_url = f"{self.base_url}/event/{event_id}/timetable/#all.detailed"
+            logger.info(f"Fetching timetable via Selenium: {timetable_url}")
+            try:
+                self.sso_scraper.driver.get(timetable_url)
+                import time
+
+                time.sleep(2)  # Wait for JavaScript to render
+                html_content = self.sso_scraper.driver.page_source
+            except Exception as e:
+                logger.warning(f"Selenium timetable fetch failed: {e}")
+
+        # Fallback to requests if Selenium didn't work
+        if not html_content:
+            timetable_urls = [
+                f"{self.base_url}/event/{event_id}/timetable/",
+                f"{self.base_url}/event/{event_id}/",
+            ]
+
+            for timetable_url in timetable_urls:
+                logger.info(f"Fetching timetable via requests: {timetable_url}")
+                try:
+                    response = session.get(timetable_url, timeout=30)
+                    response.raise_for_status()
+                    html_content = response.text
+                    break
+                except Exception as e:
+                    logger.warning(
+                        f"Error fetching timetable from {timetable_url}: {e}"
+                    )
+                    continue
+
+        if not html_content:
+            logger.warning(f"Could not fetch timetable for event {event_id}")
+            return []
+
+        # Parse the HTML
+        try:
+            soup = BeautifulSoup(html_content, "html.parser")
+
+            # Look for contribution links (most reliable pattern)
+            contrib_links = soup.select('a[href*="/contribution/"]')
+            for link in contrib_links:
+                href = link.get("href", "")
+                if "/contribution/" in href:
+                    parts = href.split("/contribution/")
+                    if len(parts) > 1:
+                        contrib_id = parts[1].split("/")[0].split("?")[0]
+                        if contrib_id and contrib_id.isdigit():
+                            title = (
+                                link.get_text(strip=True)
+                                or f"Contribution {contrib_id}"
+                            )
+                            contributions.append(
+                                {
+                                    "id": contrib_id,
+                                    "title": title,
+                                    "_from_timetable": True,
+                                    "folders": [],
+                                }
+                            )
+
+            # Look for direct material links (PDF, PPTX, etc.)
+            file_extensions = [".pdf", ".pptx", ".ppt", ".odp", ".doc", ".docx"]
+            all_links = soup.select("a[href]")
+            for link in all_links:
+                href = link.get("href", "")
+                filename = link.get_text(strip=True)
+
+                # Check if it's a material link
+                is_material = (
+                    any(href.lower().endswith(ext) for ext in file_extensions)
+                    or "/attachments/" in href
+                    or "/material/" in href
+                )
+
+                if is_material and filename:
+                    full_url = (
+                        href if href.startswith("http") else f"{self.base_url}{href}"
+                    )
+                    contributions.append(
+                        {
+                            "id": f"material_{hash(full_url) % 100000}",
+                            "title": filename,
+                            "_from_timetable": True,
+                            "_direct_material_url": full_url,
+                            "folders": [],
+                        }
+                    )
+
+        except Exception as e:
+            logger.error(f"Error parsing timetable HTML for event {event_id}: {e}")
+
+        # Deduplicate by ID and URL
+        seen = set()
+        unique_contributions = []
+        for c in contributions:
+            key = c.get("_direct_material_url") or c.get("id")
+            if key and key not in seen:
+                seen.add(key)
+                unique_contributions.append(c)
+
+        logger.info(
+            f"Found {len(unique_contributions)} contributions from timetable for event {event_id}"
+        )
+        return unique_contributions
+
+    def _collect_materials(
+        self,
+        event_id: str,
+        contribution: Dict,
+        session: requests.Session,
+        event_title: str = "",
+        event_date: str = "",
+    ) -> List[ScrapedResource]:
+        """Download and convert materials for a contribution.
+
+        Args:
+            event_id: Event ID
+            contribution: Contribution data dictionary
+            session: Authenticated session
+            event_title: Event title (for searchable metadata)
+            event_date: Event start date (for searchable metadata)
+
+        Returns:
+            List of ScrapedResource objects with markdown content
+        """
+        resources: List[ScrapedResource] = []
+
+        contribution_id = str(contribution.get("id", ""))
+
+        # Handle direct material URLs from timetable scraping
+        direct_url = contribution.get("_direct_material_url")
+        if direct_url:
+            try:
+                # Create a synthetic attachment for the direct URL
+                filename = direct_url.split("/")[-1].split("?")[0]
+                attachment = {
+                    "download_url": direct_url,
+                    "filename": filename,
+                    "title": contribution.get("title", filename),
+                }
+                resource = self._download_and_convert_material(
+                    event_id,
+                    contribution_id,
+                    contribution,
+                    attachment,
+                    session,
+                    event_title=event_title,
+                    event_date=event_date,
+                )
+                if resource:
+                    resources.append(resource)
+            except Exception as e:
+                logger.error(f"Error processing direct material URL: {e}")
+            return resources
+
+        # Standard API flow: process folders and attachments.
+        # Deduplicate by stem: when the same slides are uploaded in multiple
+        # formats (e.g. PDF + PPTX), keep only the first match in the
+        # configured format-priority order to avoid duplicate chunks.
+        folders = contribution.get("folders", [])
+        format_priority = list(
+            self.supported_formats
+        )  # e.g. ["pdf", "pptx", "ppt", "odp"]
+
+        all_attachments: List[Dict] = []
+        for folder in folders:
+            all_attachments.extend(folder.get("attachments", []))
+
+        seen_stems: dict = {}  # stem -> format priority index
+        deduplicated: List[Dict] = []
+        for attachment in all_attachments:
+            fname = attachment.get("filename", "")
+            stem = Path(fname).stem
+            ext = Path(fname).suffix.lstrip(".").lower()
+            priority = (
+                format_priority.index(ext)
+                if ext in format_priority
+                else len(format_priority)
+            )
+            prev = seen_stems.get(stem)
+            if prev is not None and priority >= prev:
+                logger.debug(
+                    f"Skipping duplicate attachment {fname} (already have {stem} in higher-priority format)"
+                )
+                continue
+            if prev is not None:
+                # Replace: this format has higher priority
+                deduplicated = [
+                    a for a in deduplicated if Path(a.get("filename", "")).stem != stem
+                ]
+            seen_stems[stem] = priority
+            deduplicated.append(attachment)
+
+        for attachment in deduplicated:
+            try:
+                resource = self._download_and_convert_material(
+                    event_id,
+                    contribution_id,
+                    contribution,
+                    attachment,
+                    session,
+                    event_title=event_title,
+                    event_date=event_date,
+                )
+                if resource:
+                    resources.append(resource)
+            except Exception as e:
+                logger.error(f"Error processing attachment: {e}")
+
+        return resources
+
+    def _download_and_convert_material(
+        self,
+        event_id: str,
+        contribution_id: str,
+        contribution: Dict,
+        attachment: Dict,
+        session: requests.Session,
+        event_title: str = "",
+        event_date: str = "",
+    ) -> Optional[ScrapedResource]:
+        """Download an attachment and convert to markdown.
+
+        Only stores the markdown conversion, not the original file.
+
+        Args:
+            event_id: Event ID
+            contribution_id: Contribution ID
+            contribution: Full contribution data
+            attachment: Attachment data dictionary
+            session: Authenticated session
+
+        Returns:
+            ScrapedResource with markdown content, or None if conversion fails
+        """
+        if not self.conversion_enabled:
+            logger.debug("Slide conversion disabled, skipping")
+            return None
+
+        filename = attachment.get("filename", "")
+        download_url = attachment.get("download_url", "")
+        content_type = attachment.get("content_type", "")
+
+        # Check if format is supported
+        file_ext = Path(filename).suffix.lstrip(".").lower()
+        if file_ext not in self.supported_formats:
+            logger.debug(f"Skipping unsupported format: {file_ext}")
+            return None
+
+        try:
+            # Download file
+            logger.info(f"Downloading material: {filename}")
+
+            # Handle relative URLs
+            if not download_url.startswith("http"):
+                download_url = urljoin(self.base_url, download_url)
+
+            response = session.get(download_url, timeout=60)
+            response.raise_for_status()
+
+            file_bytes = response.content
+            logger.info(f"Downloaded {len(file_bytes)} bytes")
+
+            # Convert to markdown
+            conversion_result = self.slide_converter.convert_bytes(
+                file_bytes,
+                content_type,
+                filename,
+            )
+
+            if conversion_result.error:
+                logger.error(f"Conversion failed: {conversion_result.error}")
+                return None
+
+            if not conversion_result.markdown:
+                logger.warning(f"Conversion produced empty markdown for {filename}")
+                return None
+
+            # Extract contribution metadata for richer context
+            contrib_title = contribution.get("title", "")
+            speaker = self._extract_speaker_name(contribution)
+            speaker_affiliation = self._extract_speaker_affiliation(contribution)
+            contrib_code = contribution.get("code", "")
+            contrib_type = contribution.get(
+                "contribution_type", contribution.get("type", "")
+            )
+            keywords = contribution.get("keywords", [])
+            start_date = contribution.get("startDate", {})
+            duration = contribution.get("duration", "")
+            session = contribution.get("session", "")
+
+            # Contribution page URL (for citing the talk, not the PDF)
+            url_contrib_id = (
+                self._get_contribution_url_id(contribution) or contribution_id
+            )
+            contribution_url = (
+                f"{self.base_url}/event/{event_id}/contributions/{url_contrib_id}/"
+            )
+
+            # Primary authors for metadata block
+            primary_authors = contribution.get("primaryauthors", [])
+            primary_author_names = [
+                (a.get("fullName") or a.get("name") or "").strip()
+                for a in primary_authors
+                if isinstance(a, dict)
+            ]
+            primary_author_names = [n for n in primary_author_names if n]
+
+            # Human-readable display name for UI and catalog (contribution title + speaker)
+            display_name = contrib_title or Path(filename).stem
+            if speaker:
+                display_name = f"{display_name} ({speaker})"
+
+            # Full metadata block at start so the chatbot can find and cite this talk
+            date_str = start_date.get("date", "") if start_date else ""
+            time_str = start_date.get("time", "") if start_date else ""
+            header_lines = []
+            if event_title:
+                header_lines.append(f"Event: {event_title}.")
+            if event_date:
+                header_lines.append(f"Event date: {event_date}.")
+            header_lines.extend(
+                [
+                    f"Contribution: {contrib_title}.",
+                    f"Speaker: {speaker}.",
+                ]
+            )
+            if primary_author_names:
+                header_lines.append(
+                    f"Primary authors: {', '.join(primary_author_names)}."
+                )
+            if date_str or time_str:
+                header_lines.append(f"Date and time: {date_str} {time_str}.")
+            if duration:
+                header_lines.append(f"Duration: {duration} minutes.")
+            if session:
+                header_lines.append(f"Session: {session}.")
+            header_lines.append("Has slides: yes.")
+            header_lines.append(f"Contribution URL: {contribution_url}")
+            header_lines.append("")
+            header = "\n".join(header_lines) + "\n"
+            content_with_header = header + conversion_result.markdown
+
+            # Create resource with markdown content
+            resource = ScrapedResource(
+                url=download_url,
+                content=content_with_header,
+                suffix="md",
+                source_type="web",
+                metadata={
+                    "scraper": "indico",
+                    "display_name": display_name,
+                    "event_id": event_id,
+                    "event_title": event_title,
+                    "event_date": event_date,
+                    "contribution_id": contribution_id,
+                    "contribution_url": contribution_url,
+                    "contribution_code": contrib_code,
+                    "contribution_title": contrib_title,
+                    "contribution_type": contrib_type if contrib_type else "",
+                    "speaker": speaker,
+                    "speaker_affiliation": speaker_affiliation,
+                    "primary_authors": (
+                        ", ".join(primary_author_names) if primary_author_names else ""
+                    ),
+                    "start_date": date_str,
+                    "start_time": time_str,
+                    "duration": str(duration) if duration else "",
+                    "session": session if session else "",
+                    "has_slides": "yes",
+                    "keywords": ", ".join(keywords) if keywords else "",
+                    "resource_type": "material",
+                    "original_filename": filename,
+                    "original_format": file_ext,
+                    "original_size_bytes": str(len(file_bytes)),
+                    "content_type": content_type,
+                    "converted_to_markdown": "true",
+                    "material_title": attachment.get("title", ""),
+                },
+                file_name=f"{Path(filename).stem}.md",
+            )
+
+            logger.info(f"Successfully converted {filename} to markdown")
+            return resource
+
+        except Exception as e:
+            logger.error(f"Error downloading/converting {filename}: {e}")
+            return None
+
+    def _create_event_resource(
+        self, event_id: str, event_data: Dict
+    ) -> Optional[ScrapedResource]:
+        """Create a resource representing event metadata.
+
+        Args:
+            event_id: Event ID
+            event_data: Event data dictionary
+
+        Returns:
+            ScrapedResource with event metadata as markdown
+        """
+        try:
+            title = event_data.get("title", "Unknown Event")
+            description = event_data.get("description", "")
+            location = event_data.get("location", "")
+            room = event_data.get("room", "")
+            roomFullname = event_data.get("roomFullname", "")
+            start_date = event_data.get("startDate", {})
+            end_date = event_data.get("endDate", {})
+            url = event_data.get("url", f"{self.base_url}/event/{event_id}/")
+            event_type = event_data.get("type", "")
+            category = event_data.get("category", "")
+            category_id = event_data.get("categoryId", "")
+            keywords = event_data.get("keywords", [])
+            organizer = event_data.get("organizer", "")
+            timezone = event_data.get("timezone", "")
+            chairs = event_data.get("chairs", [])
+
+            # Format metadata as markdown
+            markdown_content = f"# {title}\n\n"
+
+            if description:
+                markdown_content += f"{description}\n\n"
+
+            markdown_content += "## Event Details\n\n"
+
+            if event_type:
+                markdown_content += f"- **Type**: {event_type}\n"
+            if category:
+                markdown_content += f"- **Category**: {category}\n"
+            if start_date:
+                markdown_content += f"- **Start**: {start_date.get('date', '')} {start_date.get('time', '')}"
+                if timezone:
+                    markdown_content += f" ({timezone})"
+                markdown_content += "\n"
+            if end_date:
+                markdown_content += (
+                    f"- **End**: {end_date.get('date', '')} {end_date.get('time', '')}"
+                )
+                if timezone:
+                    markdown_content += f" ({timezone})"
+                markdown_content += "\n"
+            if location:
+                markdown_content += f"- **Location**: {location}"
+                if room:
+                    markdown_content += f", {room}"
+                elif roomFullname:
+                    markdown_content += f", {roomFullname}"
+                markdown_content += "\n"
+            if organizer:
+                markdown_content += f"- **Organizer**: {organizer}\n"
+
+            # Add chairs/organizers
+            if chairs:
+                chair_names = []
+                for chair in chairs:
+                    if isinstance(chair, dict):
+                        name = chair.get("fullName", chair.get("name", ""))
+                        if name:
+                            chair_names.append(name)
+                if chair_names:
+                    markdown_content += f"- **Chairs**: {', '.join(chair_names)}\n"
+
+            # Add keywords
+            if keywords:
+                markdown_content += f"- **Keywords**: {', '.join(keywords)}\n"
+
+            markdown_content += f"- **URL**: {url}\n"
+
+            resource = ScrapedResource(
+                url=url,
+                content=markdown_content,
+                suffix="md",
+                source_type="web",
+                metadata={
+                    "scraper": "indico",
+                    "event_id": event_id,
+                    "resource_type": "event",
+                    "title": title,
+                    "event_type": event_type,
+                    "category": category,
+                    "category_id": str(category_id) if category_id else "",
+                    "location": location,
+                    "room": roomFullname or room,
+                    "start_date": start_date.get("date", ""),
+                    "end_date": end_date.get("date", ""),
+                    "timezone": timezone,
+                    "organizer": organizer,
+                    "keywords": ", ".join(keywords) if keywords else "",
+                    "chairs": ", ".join(
+                        [c.get("fullName", "") for c in chairs if isinstance(c, dict)]
+                    ),
+                },
+                file_name=f"event_{event_id}.md",
+            )
+
+            return resource
+
+        except Exception as e:
+            logger.error(f"Error creating event resource: {e}")
+            return None
+
+    def _get_contribution_url_id(self, contribution: Dict) -> Optional[str]:
+        """
+        Get the contribution ID used in Indico URLs (from first attachment URL if present).
+        The API often returns a short 'id' (e.g. 81) but URLs use a longer id (e.g. 6491865).
+        """
+        for folder in contribution.get("folders", []) or []:
+            for att in folder.get("attachments", []) or []:
+                url = att.get("download_url") or att.get("url") or ""
+                match = re.search(r"/contributions/(\d+)/", url)
+                if match:
+                    return match.group(1)
+        return None
+
+    def _create_contribution_resource(
+        self,
+        event_id: str,
+        contribution: Dict,
+        event_title: str = "",
+        event_date: str = "",
+    ) -> Optional[ScrapedResource]:
+        """Create a resource representing contribution metadata.
+
+        Args:
+            event_id: Event ID
+            contribution: Contribution data dictionary
+            event_title: Event title (for searchable metadata)
+            event_date: Event start date (for searchable metadata)
+
+        Returns:
+            ScrapedResource with contribution metadata as markdown
+        """
+        try:
+            # Use URL contribution id from first attachment when available (correct /contributions/6491865/ link)
+            contrib_id = self._get_contribution_url_id(contribution) or str(
+                contribution.get("id", "")
+            )
+            title = contribution.get("title", "Unknown Contribution")
+            description = contribution.get("description", "")
+            duration = contribution.get("duration", "")
+            start_date = contribution.get("startDate", {})
+            speaker = self._extract_speaker_name(contribution)
+            speaker_affiliation = self._extract_speaker_affiliation(contribution)
+            url = f"{self.base_url}/event/{event_id}/contributions/{contrib_id}/"
+
+            # Extract additional metadata
+            code = contribution.get("code", "")
+            contrib_type = contribution.get("type", "")
+            location = contribution.get("location", "")
+            room = contribution.get("room", "")
+            roomFullname = contribution.get("roomFullname", "")
+            session = contribution.get("session", "")
+            track = contribution.get("track", "")
+            keywords = contribution.get("keywords", [])
+
+            # Extract authors
+            primary_authors = contribution.get("primaryauthors", [])
+            coauthors = contribution.get("coauthors", [])
+
+            def extract_author_names(author_list):
+                names = []
+                for author in author_list:
+                    if isinstance(author, dict):
+                        name = author.get("fullName", author.get("name", ""))
+                        if name:
+                            names.append(name)
+                return names
+
+            primary_author_names = extract_author_names(primary_authors)
+            coauthor_names = extract_author_names(coauthors)
+
+            # Format as markdown (event/date at top for searchability, same as materials)
+            markdown_content = ""
+            if event_title:
+                markdown_content += f"Event: {event_title}.\n"
+            if event_date:
+                markdown_content += f"Event date: {event_date}.\n"
+            if markdown_content:
+                markdown_content += "\n"
+            markdown_content += f"# {title}\n\n"
+
+            if code:
+                markdown_content += f"**Contribution Code**: {code}\n\n"
+
+            if speaker:
+                markdown_content += f"**Speaker**: {speaker}\n\n"
+
+            # Add authors
+            if primary_author_names:
+                markdown_content += (
+                    f"**Primary Authors**: {', '.join(primary_author_names)}\n\n"
+                )
+            if coauthor_names:
+                markdown_content += f"**Co-authors**: {', '.join(coauthor_names)}\n\n"
+
+            if description:
+                markdown_content += f"{description}\n\n"
+
+            markdown_content += "**This contribution has no slides or materials.**\n\n"
+            markdown_content += "## Details\n\n"
+
+            if contrib_type:
+                markdown_content += f"- **Type**: {contrib_type}\n"
+            if start_date:
+                markdown_content += f"- **Time**: {start_date.get('date', '')} {start_date.get('time', '')}\n"
+            if duration:
+                markdown_content += f"- **Duration**: {duration} minutes\n"
+            if location:
+                markdown_content += f"- **Location**: {location}"
+                if room:
+                    markdown_content += f", {room}"
+                elif roomFullname:
+                    markdown_content += f", {roomFullname}"
+                markdown_content += "\n"
+            if session:
+                markdown_content += f"- **Session**: {session}\n"
+            if track:
+                markdown_content += f"- **Track**: {track}\n"
+            if keywords:
+                markdown_content += f"- **Keywords**: {', '.join(keywords)}\n"
+
+            markdown_content += f"- **URL**: {url}\n"
+
+            # Human-readable display name and mark as no slides
+            display_name = f"{title} ({speaker})" if speaker else title
+            resource = ScrapedResource(
+                url=url,
+                content=markdown_content,
+                suffix="md",
+                source_type="web",
+                metadata={
+                    "scraper": "indico",
+                    "display_name": display_name,
+                    "event_id": event_id,
+                    "event_title": event_title,
+                    "event_date": event_date,
+                    "contribution_id": contrib_id,
+                    "contribution_url": url,
+                    "resource_type": "contribution",
+                    "has_slides": "no",
+                    "title": title,
+                    "code": code,
+                    "contribution_title": title,
+                    "contribution_type": contrib_type if contrib_type else "",
+                    "speaker": speaker,
+                    "speaker_affiliation": speaker_affiliation,
+                    "primary_authors": ", ".join(primary_author_names),
+                    "coauthors": ", ".join(coauthor_names),
+                    "start_date": start_date.get("date", "") if start_date else "",
+                    "start_time": start_date.get("time", "") if start_date else "",
+                    "duration": str(duration) if duration else "",
+                    "location": location,
+                    "room": roomFullname or room,
+                    "session": session if session else "",
+                    "track": track if track else "",
+                    "keywords": ", ".join(keywords) if keywords else "",
+                },
+                file_name=f"contribution_{contrib_id}.md",
+            )
+
+            return resource
+
+        except Exception as e:
+            logger.error(f"Error creating contribution resource: {e}")
+            return None
+
+    def _extract_speaker_name(self, contribution: Dict) -> str:
+        """Extract speaker name from contribution data.
+
+        Args:
+            contribution: Contribution data dictionary
+
+        Returns:
+            Speaker name or empty string
+        """
+        speakers = contribution.get("speakers", [])
+        if speakers and len(speakers) > 0:
+            first_speaker = speakers[0]
+            full_name = first_speaker.get("fullName", "")
+            if full_name:
+                return full_name
+            # Fallback to first + last name
+            first = first_speaker.get("first_name", "")
+            last = first_speaker.get("last_name", "")
+            return f"{first} {last}".strip()
+        return ""
+
+    @staticmethod
+    def _extract_speaker_affiliation(contribution: Dict) -> str:
+        """Extract the first speaker's affiliation from contribution data."""
+        speakers = contribution.get("speakers", [])
+        if speakers and isinstance(speakers[0], dict):
+            return (speakers[0].get("affiliation") or "").strip()
+        return ""
+
+    def _extract_event_id(self, url: str) -> Optional[str]:
+        """Extract event ID from Indico URL.
+
+        Args:
+            url: Indico event URL
+
+        Returns:
+            Event ID or None
+        """
+        # Match /event/123456/ or /event/123456
+        match = re.search(r"/event/(\d+)", url)
+        if match:
+            return match.group(1)
+        return None
+
+    def _extract_category_id(self, url: str) -> Optional[str]:
+        """Extract category ID from Indico URL.
+
+        Args:
+            url: Indico category URL
+
+        Returns:
+            Category ID or None
+        """
+        # Match /category/123/ or /category/123
+        match = re.search(r"/category/(\d+)", url)
+        if match:
+            return match.group(1)
+        return None

--- a/src/data_manager/collectors/scrapers/scraper_manager.py
+++ b/src/data_manager/collectors/scrapers/scraper_manager.py
@@ -1,11 +1,10 @@
-import os
 import importlib
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from src.data_manager.collectors.persistence import PersistenceService
-from src.data_manager.collectors.scrapers.scraped_resource import \
-    ScrapedResource
+from src.data_manager.collectors.scrapers.scraped_resource import ScrapedResource
 from src.data_manager.collectors.scrapers.scraper import LinkScraper
 from src.utils.config_access import get_global_config
 from src.utils.env import read_secret
@@ -14,8 +13,10 @@ from src.utils.logging import get_logger
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
-    from src.data_manager.collectors.scrapers.integrations.git_scraper import \
-        GitScraper
+    from src.data_manager.collectors.scrapers.integrations.git_scraper import GitScraper
+    from src.data_manager.collectors.scrapers.integrations.indico_scraper import (
+        IndicoScraper,
+    )
 
 
 class ScraperManager:
@@ -25,12 +26,25 @@ class ScraperManager:
         global_config = get_global_config()
 
         sources_config = (dm_config or {}).get("sources", {}) or {}
-        links_config = sources_config.get("links", {}) if isinstance(sources_config, dict) else {}
-        selenium_config = links_config.get("selenium_scraper", {}) if isinstance(sources_config, dict) else {}
+        links_config = (
+            sources_config.get("links", {}) if isinstance(sources_config, dict) else {}
+        )
+        selenium_config = (
+            links_config.get("selenium_scraper", {})
+            if isinstance(sources_config, dict)
+            else {}
+        )
 
-        git_config = sources_config.get("git", {}) if isinstance(sources_config, dict) else {}
-        sso_config = sources_config.get("sso", {}) if isinstance(sources_config, dict) else {}
-        self.base_depth = links_config.get('base_source_depth', 5)
+        git_config = (
+            sources_config.get("git", {}) if isinstance(sources_config, dict) else {}
+        )
+        sso_config = (
+            sources_config.get("sso", {}) if isinstance(sources_config, dict) else {}
+        )
+        indico_config = (
+            sources_config.get("indico", {}) if isinstance(sources_config, dict) else {}
+        )
+        self.base_depth = links_config.get("base_source_depth", 5)
         logger.debug(f"Using base depth of {self.base_depth} for weblist URLs")
 
         scraper_config = {}
@@ -46,15 +60,25 @@ class ScraperManager:
                 logger.warning(f"Invalid max_pages value {raw_max_pages}; ignoring.")
 
         self.links_enabled = True
-        self.git_enabled = git_config.get("enabled", False) if isinstance(git_config, dict) else True
+        self.git_enabled = (
+            git_config.get("enabled", False) if isinstance(git_config, dict) else True
+        )
         self.git_config = git_config if isinstance(git_config, dict) else {}
+        self.indico_enabled = (
+            indico_config.get("enabled", False)
+            if isinstance(indico_config, dict)
+            else False
+        )
+        self.indico_config = indico_config if isinstance(indico_config, dict) else {}
         self.selenium_config = selenium_config or {}
         self.selenium_enabled = self.selenium_config.get("enabled", False)
         self.scrape_with_selenium = self.selenium_config.get("use_for_scraping", False)
 
         self.sso_enabled = bool(sso_config.get("enabled", False))
 
-        elog_config = sources_config.get("elog", {}) if isinstance(sources_config, dict) else {}
+        elog_config = (
+            sources_config.get("elog", {}) if isinstance(sources_config, dict) else {}
+        )
         self.elog_config = elog_config if isinstance(elog_config, dict) else {}
         self.elog_enabled = bool(self.elog_config.get("url"))
 
@@ -65,16 +89,19 @@ class ScraperManager:
         self.data_path.mkdir(parents=True, exist_ok=True)
 
         self.web_scraper = LinkScraper(
-            verify_urls=self.config.get("verify_urls", False),  # Default to False for broader compatibility
+            verify_urls=self.config.get(
+                "verify_urls", False
+            ),  # Default to False for broader compatibility
             enable_warnings=self.config.get("enable_warnings", False),
         )
         self._git_scraper: Optional["GitScraper"] = None
-          
-    def collect_all_from_config(
-        self, persistence: PersistenceService
-    ) -> None:
+        self._indico_scraper: Optional["IndicoScraper"] = None
+
+    def collect_all_from_config(self, persistence: PersistenceService) -> None:
         """Run the configured scrapers and persist their output."""
-        link_urls, git_urls, sso_urls, elog_urls = self._collect_urls_from_lists_by_type(self.input_lists)
+        link_urls, git_urls, sso_urls, elog_urls, indico_urls = (
+            self._collect_urls_from_lists_by_type(self.input_lists)
+        )
 
         if git_urls:
             self.git_enabled = True
@@ -86,6 +113,7 @@ class ScraperManager:
         self.collect_sso(persistence, sso_urls=sso_urls)
         self.collect_git(persistence, git_urls=git_urls)
         self.collect_elog(persistence, extra_urls=elog_urls)
+        self.collect_indico(persistence, indico_urls=indico_urls)
 
         logger.info("Web scraping was completed successfully")
 
@@ -104,7 +132,9 @@ class ScraperManager:
         websites_dir = persistence.data_path / "websites"
         if not os.path.exists(websites_dir):
             os.makedirs(websites_dir, exist_ok=True)
-        return self._collect_links_from_urls(link_urls, persistence, websites_dir, max_depth=max_depth)
+        return self._collect_links_from_urls(
+            link_urls, persistence, websites_dir, max_depth=max_depth
+        )
 
     def collect_git(
         self,
@@ -121,6 +151,22 @@ class ScraperManager:
         if not os.path.exists(git_dir):
             os.makedirs(git_dir, exist_ok=True)
         self._collect_git_resources(git_urls, persistence, git_dir)
+
+    def collect_indico(
+        self,
+        persistence: PersistenceService,
+        indico_urls: Optional[List[str]] = None,
+    ) -> None:
+        """Collect Indico events and materials."""
+        if not self.indico_enabled:
+            logger.info("Indico disabled, skipping Indico scraping")
+            return
+        if not indico_urls:
+            return
+        indico_dir = persistence.data_path / "indico"
+        if not os.path.exists(indico_dir):
+            os.makedirs(indico_dir, exist_ok=True)
+        self._collect_indico_resources(indico_urls, persistence, indico_dir)
 
     def collect_sso(
         self,
@@ -139,47 +185,84 @@ class ScraperManager:
             os.makedirs(sso_dir, exist_ok=True)
         self._collect_sso_from_urls(sso_urls, persistence, sso_dir)
 
-    def schedule_collect_links(self, persistence: PersistenceService, last_run: Optional[str] = None) -> None:
+    def schedule_collect_links(
+        self, persistence: PersistenceService, last_run: Optional[str] = None
+    ) -> None:
         """
         Scheduled collection of link sources.
         For now, this behaves the same as a full collection, overriding last_run depending on the persistence layer.
         """
-        metadata = persistence.catalog.get_metadata_by_filter("source_type", source_type="web", metadata_keys=["url"])
+        metadata = persistence.catalog.get_metadata_by_filter(
+            "source_type", source_type="web", metadata_keys=["url"]
+        )
         catalog_urls = [m[1].get("url", "").strip() for m in metadata]
         catalog_urls = [u for u in catalog_urls if u]
-        logger.info("Scheduled links collection found %d URL(s) in catalog", len(catalog_urls))
+        logger.info(
+            "Scheduled links collection found %d URL(s) in catalog", len(catalog_urls)
+        )
         self.collect_links(persistence, link_urls=catalog_urls)
 
-    def schedule_collect_git(self, persistence: PersistenceService, last_run: Optional[str] = None) -> None:
-        metadata = persistence.catalog.get_metadata_by_filter("source_type", source_type="git", metadata_keys=["url"])
+    def schedule_collect_git(
+        self, persistence: PersistenceService, last_run: Optional[str] = None
+    ) -> None:
+        metadata = persistence.catalog.get_metadata_by_filter(
+            "source_type", source_type="git", metadata_keys=["url"]
+        )
         catalog_urls = [m[1].get("url", "") for m in metadata]
         self.collect_git(persistence, git_urls=catalog_urls)
 
-    def schedule_collect_sso(self, persistence: PersistenceService, last_run: Optional[str] = None) -> None:
-        metadata = persistence.catalog.get_metadata_by_filter("source_type", source_type="sso", metadata_keys=["url"])
+    def schedule_collect_indico(
+        self, persistence: PersistenceService, last_run: Optional[str] = None
+    ) -> None:
+        """Scheduled collection of Indico sources.
+
+        Indico documents share source_type="web" with link/elog scrapers, so we
+        match on the metadata-level "scraper" field instead.
+        """
+        metadata = persistence.catalog.get_metadata_by_filter(
+            "scraper", scraper="indico", metadata_keys=["url"]
+        )
+        catalog_urls = [m[1].get("url", "") for m in metadata]
+        self.collect_indico(persistence, indico_urls=catalog_urls)
+
+    def schedule_collect_sso(
+        self, persistence: PersistenceService, last_run: Optional[str] = None
+    ) -> None:
+        metadata = persistence.catalog.get_metadata_by_filter(
+            "source_type", source_type="sso", metadata_keys=["url"]
+        )
         catalog_urls = [m[1].get("url", "") for m in metadata]
         self.collect_sso(persistence, sso_urls=catalog_urls)
 
-    def schedule_collect_elog(self, persistence: PersistenceService, last_run: Optional[str] = None) -> None:
-        metadata = persistence.catalog.get_metadata_by_filter("source_type", source_type="elog", metadata_keys=["url"])
+    def schedule_collect_elog(
+        self, persistence: PersistenceService, last_run: Optional[str] = None
+    ) -> None:
+        metadata = persistence.catalog.get_metadata_by_filter(
+            "source_type", source_type="elog", metadata_keys=["url"]
+        )
         catalog_urls = [m[1].get("url", "") for m in metadata]
         self.collect_elog(persistence, extra_urls=catalog_urls)
 
-    def collect_elog(self, persistence: PersistenceService, extra_urls: Optional[List[str]] = None) -> int:
+    def collect_elog(
+        self, persistence: PersistenceService, extra_urls: Optional[List[str]] = None
+    ) -> int:
         """Collect all entries from configured ELOG logbooks.
 
         Sources:
           - dedicated  ``elog:`` config section (url key)
           - URLs auto-detected as ELOG from input_lists (passed via extra_urls)
         """
-        from src.data_manager.collectors.scrapers.integrations.elog_scraper import ElogScraper
+        from src.data_manager.collectors.scrapers.integrations.elog_scraper import (
+            ElogScraper,
+        )
+
         elog_dir = persistence.data_path / "websites"
         elog_dir.mkdir(parents=True, exist_ok=True)
 
         urls_to_scrape: List[str] = list(extra_urls) if extra_urls else []
         if self.elog_enabled:
             urls_to_scrape.append(self.elog_config.get("url"))
-        
+
         # Normalize and deduplicate URLs while preserving order
         normalized_urls: List[str] = []
         seen = set()
@@ -191,7 +274,7 @@ class ScraperManager:
                 seen.add(url)
                 normalized_urls.append(url)
         urls_to_scrape = normalized_urls
-        
+
         if not urls_to_scrape:
             return 0
 
@@ -226,12 +309,12 @@ class ScraperManager:
                 # For standard link collection, don't use selenium for scraping
                 # (SSO urls are handled separately via collect_sso)
                 count = self._handle_standard_url(
-                    url, 
-                    persistence, 
-                    output_dir, 
+                    url,
+                    persistence,
+                    output_dir,
                     max_depth=max_depth if max_depth is not None else self.base_depth,
                     client=None,
-                    use_client_for_scraping=False
+                    use_client_for_scraping=False,
                 )
                 total_count += count
         finally:
@@ -247,7 +330,9 @@ class ScraperManager:
     ) -> None:
         """Collect SSO-protected URLs using selenium for authentication."""
         if not self.selenium_enabled:
-            logger.error("SSO scraping requires data_manager.sources.links.selenium_scraper.enabled")
+            logger.error(
+                "SSO scraping requires data_manager.sources.links.selenium_scraper.enabled"
+            )
             return
         if not read_secret("SSO_USERNAME") or not read_secret("SSO_PASSWORD"):
             logger.error("SSO scraping requires SSO_USERNAME and SSO_PASSWORD secrets")
@@ -257,9 +342,11 @@ class ScraperManager:
             authenticator_class, kwargs = self._resolve_scraper()
             if authenticator_class is not None:
                 authenticator = authenticator_class(**kwargs)
-        
+
         if authenticator is None:
-            logger.error("SSO collection requires a valid selenium scraper configuration")
+            logger.error(
+                "SSO collection requires a valid selenium scraper configuration"
+            )
             return
 
         try:
@@ -272,7 +359,7 @@ class ScraperManager:
                     output_dir,
                     max_depth=self.base_depth,
                     client=authenticator,
-                    use_client_for_scraping=self.scrape_with_selenium
+                    use_client_for_scraping=self.scrape_with_selenium,
                 )
         finally:
             if authenticator is not None:
@@ -315,12 +402,15 @@ class ScraperManager:
 
         return urls
 
-    def _collect_urls_from_lists_by_type(self, input_lists: List[str]) -> tuple[List[str], List[str], List[str], List[str]]:
+    def _collect_urls_from_lists_by_type(
+        self, input_lists: List[str]
+    ) -> tuple[List[str], List[str], List[str], List[str], List[str]]:
         """All types of URLs are in the same input lists, separate them via prefixes or auto-detection."""
         link_urls: List[str] = []
-        git_urls:  List[str] = []
-        sso_urls:  List[str] = []
+        git_urls: List[str] = []
+        sso_urls: List[str] = []
         elog_urls: List[str] = []
+        indico_urls: List[str] = []
         for raw_url in self._collect_urls_from_lists(input_lists):
             if raw_url.startswith("git-"):
                 git_urls.append(raw_url.split("git-", 1)[1])
@@ -334,8 +424,14 @@ class ScraperManager:
             if self._is_elog_url(raw_url):
                 elog_urls.append(raw_url)
                 continue
+            if raw_url.startswith("indico-"):
+                indico_urls.append(raw_url.split("indico-", 1)[1])
+                continue
+            if self._is_indico_url(raw_url):
+                indico_urls.append(raw_url)
+                continue
             link_urls.append(raw_url)
-        return link_urls, git_urls, sso_urls, elog_urls
+        return link_urls, git_urls, sso_urls, elog_urls, indico_urls
 
     @staticmethod
     def _is_elog_url(url: str) -> bool:
@@ -343,40 +439,68 @@ class ScraperManager:
         Prefer the explicit 'elog-' prefix in input lists over this auto-detection.
         """
         from urllib.parse import urlparse
+
         path = urlparse(url).path.lower()
         return "/elog/" in path or "/elogs/" in path
+
+    def _is_indico_url(self, url: str) -> bool:
+        """Return True if the URL looks like an Indico event page.
+
+        Matches when the path contains ``/event/`` and either:
+        - the hostname equals the configured ``indico.base_url`` hostname, or
+        - the hostname contains the word ``indico`` (covers any Indico instance,
+          e.g. indico.cern.ch, indico.stfc.ac.uk, indico.fnal.gov, ...).
+
+        The explicit ``indico-`` prefix in input lists is still supported and
+        takes precedence over this auto-detection.
+        """
+        if not self.indico_enabled:
+            return False
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        path = parsed.path.lower()
+        if "/event/" not in path:
+            return False
+        configured_host = urlparse(self.indico_config.get("base_url", "")).hostname
+        if configured_host and hostname == configured_host:
+            return True
+        return "indico" in hostname
+
     def _resolve_scraper(self):
         class_name = self.selenium_config.get("selenium_class")
         class_map = self.selenium_config.get("selenium_class_map", {})
-        selenium_url = self.selenium_config.get("selenium_url",None)
+        selenium_url = self.selenium_config.get("selenium_url", None)
 
         entry = class_map.get(class_name)
 
-        if not entry: 
-            logger.error(f"Selenium class {class_name} is not defined in the configuration")
+        if not entry:
+            logger.error(
+                f"Selenium class {class_name} is not defined in the configuration"
+            )
             return None, {}
 
         scraper_class = entry.get("class")
         if isinstance(scraper_class, str):
             module_name = entry.get(
-                    "module", 
-                    "src.data_manager.collectors.scrapers.integrations.sso_scraper",
-                    )
+                "module",
+                "src.data_manager.collectors.scrapers.integrations.sso_scraper",
+            )
             module = importlib.import_module(module_name)
             scraper_class = getattr(module, scraper_class)
         scraper_kwargs = entry.get("kwargs", {})
         scraper_kwargs["selenium_url"] = selenium_url
         return scraper_class, scraper_kwargs
 
-
     def _handle_standard_url(
-            self, 
-            url: str, 
-            persistence: PersistenceService, 
-            output_dir: Path, 
-            max_depth: int, 
-            client=None, 
-            use_client_for_scraping: bool = False,
+        self,
+        url: str,
+        persistence: PersistenceService,
+        output_dir: Path,
+        max_depth: int,
+        client=None,
+        use_client_for_scraping: bool = False,
     ) -> int:
         """Scrape a URL and persist resources. Returns count of resources scraped."""
         count = 0
@@ -388,9 +512,7 @@ class ScraperManager:
                 selenium_scrape=use_client_for_scraping,
                 max_pages=self.max_pages,
             ):
-                persistence.persist_resource(
-                    resource, output_dir
-                )
+                persistence.persist_resource(resource, output_dir)
                 count += 1
             logger.info(f"Scraped {count} resources from {url}")
         except Exception as exc:
@@ -425,8 +547,33 @@ class ScraperManager:
 
     def _get_git_scraper(self) -> "GitScraper":
         if self._git_scraper is None:
-            from src.data_manager.collectors.scrapers.integrations.git_scraper import \
-                    GitScraper
+            from src.data_manager.collectors.scrapers.integrations.git_scraper import (
+                GitScraper,
+            )
 
             self._git_scraper = GitScraper(manager=self, git_config=self.git_config)
         return self._git_scraper
+
+    def _collect_indico_resources(
+        self,
+        indico_urls: List[str],
+        persistence: PersistenceService,
+        indico_dir: Path,
+    ) -> List[ScrapedResource]:
+        """Collect Indico events and materials."""
+        indico_scraper = self._get_indico_scraper()
+        resources = indico_scraper.collect(indico_urls)
+        for resource in resources:
+            persistence.persist_resource(resource, indico_dir)
+        return resources
+
+    def _get_indico_scraper(self) -> "IndicoScraper":
+        if self._indico_scraper is None:
+            from src.data_manager.collectors.scrapers.integrations.indico_scraper import (
+                IndicoScraper,
+            )
+
+            self._indico_scraper = IndicoScraper(
+                manager=self, indico_config=self.indico_config
+            )
+        return self._indico_scraper

--- a/src/data_manager/collectors/utils/slide_converter.py
+++ b/src/data_manager/collectors/utils/slide_converter.py
@@ -1,0 +1,226 @@
+"""Utility for converting presentation files to markdown using MarkItDown."""
+
+import io
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Union
+
+from markitdown import MarkItDown
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ConversionResult:
+    """Result of a slide-to-markdown conversion."""
+
+    markdown: str
+    source_path: Optional[Path] = None
+    source_filename: Optional[str] = None
+    error: Optional[str] = None
+
+
+class SlideConverter:
+    """Convert presentation files to markdown using MarkItDown.
+
+    Supports PDF, PPTX, PPT, ODP, and other formats supported by MarkItDown.
+    Includes extensibility hooks for future plot/figure processing.
+    """
+
+    def __init__(self, llm_client=None, llm_model=None):
+        """Initialize the slide converter.
+
+        Args:
+            llm_client: Optional LLM client for image descriptions (future use)
+            llm_model: Optional LLM model name for image descriptions (future use)
+        """
+        self.md = MarkItDown(
+            enable_plugins=False,
+            llm_client=llm_client,
+            llm_model=llm_model,
+        )
+        self._plot_hooks: List[Callable] = []
+        logger.info("SlideConverter initialized")
+
+    def convert(
+        self, file_path: Union[str, Path], content_type: Optional[str] = None
+    ) -> ConversionResult:
+        """Convert a slide file to markdown.
+
+        Args:
+            file_path: Path to the file to convert
+            content_type: Optional MIME type hint
+
+        Returns:
+            ConversionResult with markdown content
+        """
+        try:
+            file_path = Path(file_path)
+            if not file_path.exists():
+                return ConversionResult(
+                    markdown="",
+                    source_path=file_path,
+                    error=f"File not found: {file_path}",
+                )
+
+            logger.info(f"Converting file to markdown: {file_path.name}")
+            result = self.md.convert(str(file_path))
+
+            markdown = (
+                result.text_content if hasattr(result, "text_content") else str(result)
+            )
+            markdown = self._clean_markdown(markdown)
+
+            logger.info(
+                f"Converted {file_path.name} to markdown ({len(markdown)} chars)"
+            )
+
+            return ConversionResult(
+                markdown=markdown,
+                source_path=file_path,
+                source_filename=file_path.name,
+            )
+
+        except Exception as e:
+            logger.error(f"Error converting {file_path}: {e}")
+            return ConversionResult(
+                markdown="",
+                source_path=file_path,
+                source_filename=file_path.name if isinstance(file_path, Path) else None,
+                error=str(e),
+            )
+
+    def convert_bytes(
+        self, file_bytes: bytes, content_type: str, filename: Optional[str] = None
+    ) -> ConversionResult:
+        """Convert file bytes to markdown.
+
+        This is useful for converting downloaded attachments without saving to disk.
+
+        Args:
+            file_bytes: File content as bytes
+            content_type: MIME type (e.g., 'application/pdf')
+            filename: Optional filename hint for extension detection
+
+        Returns:
+            ConversionResult with markdown content
+        """
+        try:
+            # Determine file extension from content_type or filename
+            extension = self._get_extension_from_content_type(content_type, filename)
+
+            # Create a temporary file to feed to MarkItDown
+            # (MarkItDown's convert() method expects a file path)
+            with tempfile.NamedTemporaryFile(
+                suffix=extension, delete=False
+            ) as tmp_file:
+                tmp_file.write(file_bytes)
+                tmp_path = Path(tmp_file.name)
+
+            try:
+                logger.info(
+                    f"Converting bytes to markdown (type: {content_type}, size: {len(file_bytes)} bytes)"
+                )
+                result = self.md.convert(str(tmp_path))
+
+                markdown = (
+                    result.text_content
+                    if hasattr(result, "text_content")
+                    else str(result)
+                )
+                markdown = self._clean_markdown(markdown)
+
+                logger.info(f"Converted to markdown ({len(markdown)} chars)")
+
+                return ConversionResult(
+                    markdown=markdown,
+                    source_filename=filename,
+                )
+            finally:
+                # Clean up temporary file
+                tmp_path.unlink(missing_ok=True)
+
+        except Exception as e:
+            logger.error(f"Error converting bytes (type: {content_type}): {e}")
+            return ConversionResult(markdown="", source_filename=filename, error=str(e))
+
+    # Regex matching <latexit ...>...</latexit> blocks that MarkItDown extracts
+    # from PDFs with embedded LaTeX.  These base64-encoded blobs add no
+    # retrieval value and can inflate chunk counts by 5-10x on formula-heavy
+    # slides (e.g. physics keynotes).
+    _LATEXIT_RE = re.compile(
+        r"<latexit\b[^>]*>.*?</latexit>",
+        re.DOTALL,
+    )
+
+    @classmethod
+    def _clean_markdown(cls, markdown: str) -> str:
+        """Post-process converted markdown to remove noise."""
+        # Strip <latexit> blocks
+        cleaned = cls._LATEXIT_RE.sub("", markdown)
+        # Collapse runs of blank lines left behind by the removal
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+        return cleaned.strip()
+
+    def register_plot_hook(self, hook: Callable) -> None:
+        """Register a hook for future plot processing.
+
+        This is a placeholder for future extensibility. Plot hooks can be
+        called after conversion to extract and analyze plots/figures.
+
+        Args:
+            hook: Callable that processes plot data
+        """
+        self._plot_hooks.append(hook)
+        logger.info(
+            f"Registered plot hook: {hook.__name__ if hasattr(hook, '__name__') else 'unnamed'}"
+        )
+
+    def _get_extension_from_content_type(
+        self, content_type: str, filename: Optional[str] = None
+    ) -> str:
+        """Determine file extension from content type or filename.
+
+        Args:
+            content_type: MIME type
+            filename: Optional filename
+
+        Returns:
+            File extension with leading dot (e.g., '.pdf')
+        """
+        # Try to get extension from filename first
+        if filename:
+            ext = Path(filename).suffix
+            if ext:
+                return ext
+
+        # Map common content types to extensions
+        content_type_map = {
+            "application/pdf": ".pdf",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+            "application/vnd.ms-powerpoint": ".ppt",
+            "application/vnd.oasis.opendocument.presentation": ".odp",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+            "application/msword": ".doc",
+        }
+
+        return content_type_map.get(content_type, ".bin")
+
+    def _extract_image_refs(self, result) -> List[str]:
+        """Extract image references from conversion result.
+
+        This is a placeholder for future plot extraction functionality.
+
+        Args:
+            result: MarkItDown conversion result
+
+        Returns:
+            List of image references/paths
+        """
+        # Future: Parse markdown for image references
+        # Future: Call registered plot hooks
+        return []

--- a/src/data_manager/vectorstore/manager.py
+++ b/src/data_manager/vectorstore/manager.py
@@ -8,17 +8,19 @@ from typing import Any, Dict, List, Optional
 import nltk
 import psycopg2
 import psycopg2.extras
-from .loader_utils import select_loader
-from .postgres_vectorstore import PostgresVectorStore
 from langchain_text_splitters.character import CharacterTextSplitter
 
 from src.data_manager.collectors.utils.catalog_postgres import PostgresCatalogService
 from src.utils.env import read_secret
 from src.utils.logging import get_logger
 
+from .loader_utils import select_loader
+from .postgres_vectorstore import PostgresVectorStore
+
 logger = get_logger(__name__)
 
 SUPPORTED_DISTANCE_METRICS = ["l2", "cosine", "ip"]
+
 
 class VectorStoreManager:
     """
@@ -48,7 +50,9 @@ class VectorStoreManager:
                 **self._services_config["postgres"],
             }
         self._pg_config = pg_config
-        self._catalog = PostgresCatalogService(self.data_path, pg_config=self._pg_config)
+        self._catalog = PostgresCatalogService(
+            self.data_path, pg_config=self._pg_config
+        )
 
         embedding_name = self._data_manager_config["embedding_name"]
         self.collection_name = (
@@ -65,7 +69,10 @@ class VectorStoreManager:
         # Build embedding model
         embedding_class_map = self._data_manager_config["embedding_class_map"]
         from src.utils.config_service import ConfigService
-        embedding_class_map = ConfigService._resolve_embedding_classes(embedding_class_map)
+
+        embedding_class_map = ConfigService._resolve_embedding_classes(
+            embedding_class_map
+        )
 
         embedding_entry = embedding_class_map[embedding_name]
         embedding_class = embedding_entry["class"]
@@ -98,7 +105,9 @@ class VectorStoreManager:
                 self.parallel_workers = default_workers
         self.parallel_workers = max(1, self.parallel_workers)
 
-        logger.info(f"VectorStoreManager initialized: collection={self.collection_name}")
+        logger.info(
+            f"VectorStoreManager initialized: collection={self.collection_name}"
+        )
 
     def delete_existing_collection_if_reset(self) -> None:
         """Delete the collection if reset_collection is enabled.
@@ -136,7 +145,8 @@ class VectorStoreManager:
                 logger.info(
                     "reset_collection is enabled; truncated document_chunks, "
                     "reset %d documents for collection %s",
-                    reset_docs, self.collection_name,
+                    reset_docs,
+                    self.collection_name,
                 )
         except Exception as exc:
             logger.error("Failed during collection reset: %s", exc)
@@ -178,7 +188,9 @@ class VectorStoreManager:
         """Synchronise filesystem documents with the vectorstore."""
         store = self.fetch_collection()
 
-        sources = PostgresCatalogService.load_sources_catalog(self.data_path, self._pg_config)
+        sources = PostgresCatalogService.load_sources_catalog(
+            self.data_path, self._pg_config
+        )
         logger.info(f"Loaded {len(sources)} sources from catalog")
 
         # Get hashes currently in vectorstore
@@ -187,7 +199,9 @@ class VectorStoreManager:
 
         hashes_in_data = set(files_in_data.keys())
 
-        logger.info(f"Files in catalog: {len(hashes_in_data)}, Files in vectorstore: {len(hashes_in_vstore)}")
+        logger.info(
+            f"Files in catalog: {len(hashes_in_data)}, Files in vectorstore: {len(hashes_in_vstore)}"
+        )
 
         if hashes_in_data == hashes_in_vstore:
             logger.info("Vectorstore is up to date")
@@ -208,7 +222,7 @@ class VectorStoreManager:
                 try:
                     self._add_to_postgres(files_to_add)
                 except Exception as e:
-                    logger.error(f"Files could not be added",exc_info=e)
+                    logger.error(f"Files could not be added", exc_info=e)
             logger.info("Vectorstore update has been completed")
 
         logger.info(f"N Collection: {store.count()}")
@@ -225,7 +239,7 @@ class VectorStoreManager:
                     WHERE (metadata->>'collection' = %s OR metadata->>'collection' IS NULL)
                       AND metadata->>'resource_hash' IS NOT NULL
                     """,
-                    (self.collection_name,)
+                    (self.collection_name,),
                 )
                 return {row[0] for row in cursor.fetchall()}
         finally:
@@ -243,10 +257,12 @@ class VectorStoreManager:
                         WHERE metadata->>'resource_hash' = %s
                           AND (metadata->>'collection' = %s OR metadata->>'collection' IS NULL)
                         """,
-                        (resource_hash, self.collection_name)
+                        (resource_hash, self.collection_name),
                     )
                 conn.commit()
-                logger.debug(f"Removed {len(hashes_to_remove)} resource hashes from vectorstore")
+                logger.debug(
+                    f"Removed {len(hashes_to_remove)} resource hashes from vectorstore"
+                )
         finally:
             conn.close()
 
@@ -261,7 +277,9 @@ class VectorStoreManager:
             self._catalog.update_ingestion_status(filehash, "embedding")
 
         files_to_add_items = list(files_to_add.items())
-        apply_stemming = self._data_manager_config.get("stemming", {}).get("enabled", False)
+        apply_stemming = self._data_manager_config.get("stemming", {}).get(
+            "enabled", False
+        )
         if apply_stemming:
             tokenize = nltk.tokenize.word_tokenize
             stem = self.stemmer.stem
@@ -273,19 +291,25 @@ class VectorStoreManager:
             try:
                 loader = self.loader(file_path)
             except Exception as exc:
-                logger.error(f"Failed to load file: {file_path}. Skipping. Exception: {exc}")
+                logger.error(
+                    f"Failed to load file: {file_path}. Skipping. Exception: {exc}"
+                )
                 self._catalog.update_ingestion_status(filehash, "failed", str(exc))
                 return None
 
             if loader is None:
-                self._catalog.update_ingestion_status(filehash, "failed", f"Unsupported file format: {file_path}")
+                self._catalog.update_ingestion_status(
+                    filehash, "failed", f"Unsupported file format: {file_path}"
+                )
                 return None
 
             file_level_metadata = self._load_file_metadata(filehash)
             try:
                 docs = loader.load()
             except Exception as exc:
-                logger.error("Failed to read file %s. Skipping. Exception: %s", file_path, exc)
+                logger.error(
+                    "Failed to read file %s. Skipping. Exception: %s", file_path, exc
+                )
                 self._catalog.update_ingestion_status(filehash, "failed", str(exc))
                 return None
 
@@ -294,11 +318,52 @@ class VectorStoreManager:
             chunks: List[str] = []
             metadatas: List[Dict] = []
 
+            # Prepend a short metadata line to every chunk for Indico only, so retrieval
+            # can find talks by event, date, contribution, or speaker. Other web/git/sso/
+            # ticket/local_files documents must not get this prefix. Indico shares
+            # source_type="web" with the link/elog scrapers, so we gate on the
+            # integration-specific "scraper" metadata field instead.
+            scraper = (file_level_metadata or {}).get("scraper")
+            chunk_prefix = ""
+            if isinstance(scraper, str) and scraper.strip().lower() == "indico":
+                meta = file_level_metadata or {}
+                event_title = meta.get("event_title")
+                event_date = meta.get("event_date")
+                contrib_title = meta.get("contribution_title") or meta.get("title")
+                speaker = meta.get("speaker")
+                speaker_affiliation = meta.get("speaker_affiliation")
+                start_time = meta.get("start_time")
+                duration = meta.get("duration")
+                session = meta.get("session")
+                parts = []
+                if event_title:
+                    parts.append(f"Event: {event_title}.")
+                if event_date:
+                    parts.append(f"Event date: {event_date}.")
+                if contrib_title:
+                    parts.append(f"Contribution: {contrib_title}.")
+                if speaker:
+                    parts.append(f"Speaker: {speaker}.")
+                if speaker_affiliation:
+                    parts.append(f"Affiliation: {speaker_affiliation}.")
+                if start_time:
+                    parts.append(f"Start time: {start_time}.")
+                if duration:
+                    parts.append(f"Duration: {duration} min.")
+                if session:
+                    parts.append(f"Session: {session}.")
+                if parts:
+                    chunk_prefix = " ".join(parts) + "\n\n"
+
             for index, split_doc in enumerate(split_docs):
                 chunk = split_doc.page_content or ""
                 # Remove NUL bytes that PostgreSQL cannot handle
-                chunk = chunk.replace('\x00', '')
-                
+                chunk = chunk.replace("\x00", "")
+
+                # Prepend Indico metadata so retrieval can match by event/speaker.
+                if chunk_prefix:
+                    chunk = chunk_prefix + chunk
+
                 if apply_stemming:
                     words = tokenize(chunk)
                     chunk = " ".join(stem(word) for word in words)
@@ -320,7 +385,9 @@ class VectorStoreManager:
 
             if not chunks:
                 logger.info(f"No chunks generated for {filename}; skipping.")
-                self._catalog.update_ingestion_status(filehash, "failed", "No text chunks could be extracted")
+                self._catalog.update_ingestion_status(
+                    filehash, "failed", "No text chunks could be extracted"
+                )
                 return None
 
             return filename, chunks, metadatas
@@ -356,7 +423,7 @@ class VectorStoreManager:
         try:
             with conn.cursor() as cursor:
                 import json
-                
+
                 total_files = len(files_to_add_items)
                 files_since_commit = 0
                 for file_idx, (filehash, file_path) in enumerate(files_to_add_items):
@@ -365,7 +432,9 @@ class VectorStoreManager:
                         continue
 
                     filename, chunks, metadatas = processed
-                    logger.info(f"Embedding file {file_idx+1}/{total_files}: {filename} ({len(chunks)} chunks)")
+                    logger.info(
+                        f"Embedding file {file_idx+1}/{total_files}: {filename} ({len(chunks)} chunks)"
+                    )
 
                     savepoint_name = f"sp_embed_{file_idx}"
                     cursor.execute(f"SAVEPOINT {savepoint_name}")
@@ -384,33 +453,44 @@ class VectorStoreManager:
                         files_since_commit += 1
                         if files_since_commit >= commit_batch_size:
                             conn.commit()
-                            logger.info("Committed embedding progress batch (%d files)", files_since_commit)
+                            logger.info(
+                                "Committed embedding progress batch (%d files)",
+                                files_since_commit,
+                            )
                             files_since_commit = 0
                         continue
 
                     logger.info(f"Finished embedding {filename}")
-                    
+
                     # Get document_id from the catalog (documents table)
                     document_id = self._catalog.get_document_id(filehash)
                     if document_id is None:
-                        logger.warning(f"No document record found for {filehash}, chunks will have NULL document_id")
+                        logger.warning(
+                            f"No document record found for {filehash}, chunks will have NULL document_id"
+                        )
 
                     insert_data = []
-                    for idx, (chunk, embedding, metadata) in enumerate(zip(chunks, embeddings, metadatas)):
+                    for idx, (chunk, embedding, metadata) in enumerate(
+                        zip(chunks, embeddings, metadatas)
+                    ):
                         # Ensure no NUL bytes in chunk or metadata JSON
-                        clean_chunk = chunk.replace('\x00', '')
-                        clean_metadata_json = json.dumps(metadata).replace('\x00', '')
-                        
-                        insert_data.append((
-                            document_id,  # Link to documents table
-                            idx,   # chunk_index
-                            clean_chunk,
-                            embedding,
-                            clean_metadata_json,
-                        ))
+                        clean_chunk = chunk.replace("\x00", "")
+                        clean_metadata_json = json.dumps(metadata).replace("\x00", "")
+
+                        insert_data.append(
+                            (
+                                document_id,  # Link to documents table
+                                idx,  # chunk_index
+                                clean_chunk,
+                                embedding,
+                                clean_metadata_json,
+                            )
+                        )
 
                     try:
-                        logger.debug(f"Inserting data in {filename} document_id = {document_id}")
+                        logger.debug(
+                            f"Inserting data in {filename} document_id = {document_id}"
+                        )
                         psycopg2.extras.execute_values(
                             cursor,
                             """
@@ -420,7 +500,9 @@ class VectorStoreManager:
                             insert_data,
                             template="(%s, %s, %s, %s::vector, %s::jsonb)",
                         )
-                        logger.debug(f"Added {len(insert_data)} chunks for {filename} (document_id={document_id})")
+                        logger.debug(
+                            f"Added {len(insert_data)} chunks for {filename} (document_id={document_id})"
+                        )
 
                         # Update timestamps and mark as embedded
                         cursor.execute(
@@ -445,12 +527,18 @@ class VectorStoreManager:
                     files_since_commit += 1
                     if files_since_commit >= commit_batch_size:
                         conn.commit()
-                        logger.info("Committed embedding progress batch (%d files)", files_since_commit)
+                        logger.info(
+                            "Committed embedding progress batch (%d files)",
+                            files_since_commit,
+                        )
                         files_since_commit = 0
 
                 if files_since_commit > 0:
                     conn.commit()
-                    logger.info("Committed final embedding progress batch (%d files)", files_since_commit)
+                    logger.info(
+                        "Committed final embedding progress batch (%d files)",
+                        files_since_commit,
+                    )
         finally:
             conn.close()
 
@@ -485,7 +573,9 @@ class VectorStoreManager:
                 )
                 continue
 
-            if resource_hash in files_in_data and files_in_data[resource_hash] != str(path):
+            if resource_hash in files_in_data and files_in_data[resource_hash] != str(
+                path
+            ):
                 logger.warning(
                     "Duplicate resource hash detected in index; keeping first occurrence. "
                     f"hash={resource_hash}, existing={files_in_data[resource_hash]}, ignored={path}"
@@ -495,10 +585,14 @@ class VectorStoreManager:
             files_in_data[resource_hash] = str(path)
 
         if missing_files:
-            logger.warning(f"Found {len(missing_files)} missing files in catalog (first 5): {missing_files[:5]}")
+            logger.warning(
+                f"Found {len(missing_files)} missing files in catalog (first 5): {missing_files[:5]}"
+            )
         if skipped_dirs:
             logger.debug(f"Skipped {len(skipped_dirs)} directories in catalog")
-        logger.info(f"Collected {len(files_in_data)} valid indexed documents (after filtering missing/dirs)")
+        logger.info(
+            f"Collected {len(files_in_data)} valid indexed documents (after filtering missing/dirs)"
+        )
 
         return files_in_data
 


### PR DESCRIPTION
Adds support for scraping Indico events and meeting materials, alongside the existing scrapers.

Scraper (indico_scraper.py)
- Fetches event metadata, contributions, and slide attachments via the Indico REST API.
- Converts PDF/PPTX/PPT/ODP slides to Markdown via MarkItDown; strips embedded <latexit> blocks that inflate chunk counts on formula-heavy slides (slide_converter.py).
- Deduplicates attachments when the same slides are uploaded in multiple formats (e.g. PDF + PPTX): keeps the higher-priority format.
- Detects SSO-protected events and authenticates via CERNSSOScraper.

ScraperManager integration
- collect_indico() / schedule_collect_indico() hooks.
- URL routing: explicit "indico-" prefix in weblists, plus auto-detection for URLs with "indico" in the hostname and /event/ in the path.
- Indico documents use source_type="web" (matching the existing CHECK constraint) with a "scraper": "indico" metadata field for filtering.
- Most of the changes to the scraper_manager.py is just linting 

Vectorstore
- Prepends a one-line metadata header to each Indico chunk (event title, date, contribution, speaker, affiliation, start time, duration, session) so BM25 retrieval can match on speaker name, time of day, etc. Gated on metadata "scraper"="indico"; no other sources affected.

Config / docs / examples
- base-config.yaml: indico source block (disabled by default).
- docs/docs/data_sources.md: Indico section.
- examples/agents/indico-assistant.md: agent spec for Indico queries.
- examples/deployments/basic-agent/indico_example.list: example weblist.
- SourceRegistry: register "indico" source (depends on links).

Dependencies
- pyproject.toml + requirements-base.txt: add markitdown[pdf,pptx].

Known limitations
- Images and figures in slides are not extracted or described; only text content is converted to Markdown. Slides that communicate primarily through plots/diagrams will produce thin or empty chunks.
- LaTeX in slides: embedded <latexit> blocks are stripped (they are base64-encoded and useless for retrieval), but inline LaTeX notation and formula-heavy slides may still produce low-quality Markdown that chunks poorly.
- Slide context is per-page, not per-deck: each chunk comes from one page/section of the converted Markdown. There is no cross-slide summarisation, so a narrative that spans multiple slides may be split across chunks without connecting context.
- Category URLs (/category/<id>/) are handled in the code but not yet tested end-to-end; only event URLs are documented.
- SSO authentication is CERN-specific (CERNSSOScraper). Other Indico instances with different login flows would need a different auth path.
- No rate limiting or incremental scraping; large events with many attachments are processed in a single run.
- indico_scraper.py is large (~1300 lines); a follow-up refactor could
  split API interaction from resource construction.