### PR TITLE
Fix RBAC pyright type errors and add unit tests

### DIFF
--- a/src/utils/rbac/decorators.py
+++ b/src/utils/rbac/decorators.py
@@ -68,7 +68,7 @@ def require_authenticated(f: Callable) -> Callable:
                 user='anonymous',
                 permission='authenticated',
                 granted=False,
-                endpoint=request.endpoint,
+                endpoint=request.endpoint or '<unknown>',
                 roles=[]
             )
             
@@ -118,7 +118,7 @@ def require_permission(permission: Union[str, List[str]]) -> Callable:
                     user='anonymous',
                     permission=','.join(required_permissions),
                     granted=False,
-                    endpoint=request.endpoint,
+                    endpoint=request.endpoint or '<unknown>',
                     roles=[]
                 )
                 
@@ -150,7 +150,7 @@ def require_permission(permission: Union[str, List[str]]) -> Callable:
                     user=user_email,
                     permission=','.join(required_permissions),
                     granted=False,
-                    endpoint=request.endpoint,
+                    endpoint=request.endpoint or '<unknown>',
                     roles=user_roles,
                     missing=missing_permissions
                 )
@@ -184,7 +184,7 @@ def require_permission(permission: Union[str, List[str]]) -> Callable:
                 user=user_email,
                 permission=','.join(required_permissions),
                 granted=True,
-                endpoint=request.endpoint,
+                endpoint=request.endpoint or '<unknown>',
                 roles=user_roles
             )
             
@@ -216,7 +216,7 @@ def require_any_permission(permissions: List[str]) -> Callable:
                     user='anonymous',
                     permission=f"any({','.join(permissions)})",
                     granted=False,
-                    endpoint=request.endpoint,
+                    endpoint=request.endpoint or '<unknown>',
                     roles=[]
                 )
                 
@@ -249,7 +249,7 @@ def require_any_permission(permissions: List[str]) -> Callable:
                     user=user_email,
                     permission=f"any({','.join(permissions)})",
                     granted=False,
-                    endpoint=request.endpoint,
+                    endpoint=request.endpoint or '<unknown>',
                     roles=user_roles
                 )
                 
@@ -281,7 +281,7 @@ def require_any_permission(permissions: List[str]) -> Callable:
                 user=user_email,
                 permission=f"any({','.join(permissions)})",
                 granted=True,
-                endpoint=request.endpoint,
+                endpoint=request.endpoint or '<unknown>',
                 roles=user_roles
             )
             
@@ -316,7 +316,7 @@ def check_sso_required() -> Callable:
                     user='anonymous',
                     permission='sso_required',
                     granted=False,
-                    endpoint=request.endpoint,
+                    endpoint=request.endpoint or '<unknown>',
                     roles=[]
                 )
                 

--- a/src/utils/rbac/jwt_parser.py
+++ b/src/utils/rbac/jwt_parser.py
@@ -155,7 +155,7 @@ def get_user_roles(
         return assign_default_role(user_email, raw_roles)
 
 
-def assign_default_role(user_email: str, original_roles: List[str] = None) -> List[str]:
+def assign_default_role(user_email: str, original_roles: Optional[List[str]] = None) -> List[str]:
     """
     Assign the default role to a user who has no configured roles.
     

--- a/src/utils/rbac/registry.py
+++ b/src/utils/rbac/registry.py
@@ -145,7 +145,7 @@ class RBACRegistry:
         
         logger.debug(f"Permission cache built for {len(self._role_permissions_cache)} roles")
     
-    def _resolve_permissions(self, role_name: str, visited: Set[str] = None) -> Set[str]:
+    def _resolve_permissions(self, role_name: str, visited: Optional[Set[str]] = None) -> Set[str]:
         """
         Resolve all permissions for a role including inherited permissions.
         

--- a/tests/unit/test_rbac_audit.py
+++ b/tests/unit/test_rbac_audit.py
@@ -1,0 +1,138 @@
+"""Tests for RBAC audit logging — log_authentication_event, log_permission_check, log_role_assignment."""
+
+from unittest.mock import patch
+
+import pytest
+from src.utils.rbac.audit import (
+    log_authentication_event,
+    log_permission_check,
+    log_role_assignment,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_audit_logger():
+    """Patch the audit_logger used by all three functions."""
+    with patch("src.utils.rbac.audit.audit_logger") as mock_logger:
+        yield mock_logger
+
+
+# ---------------------------------------------------------------------------
+# 3.6  log_authentication_event: success / failure
+# ---------------------------------------------------------------------------
+
+
+class TestLogAuthenticationEvent:
+    def test_success_logs_info(self, mock_audit_logger):
+        log_authentication_event("user@test.com", "login", success=True, method="sso")
+
+        # Should log at info level for success
+        info_calls = [
+            str(c) for c in mock_audit_logger.info.call_args_list
+        ]
+        assert any("AUTH" in c and "login" in c and "user@test.com" in c and "SUCCESS" in c for c in info_calls)
+
+    def test_failure_logs_warning(self, mock_audit_logger):
+        log_authentication_event(
+            "unknown", "api_token_auth", success=False,
+            method="bearer_token", details="No token",
+        )
+
+        # Should log at warning level for failure
+        warning_calls = [
+            str(c) for c in mock_audit_logger.warning.call_args_list
+        ]
+        assert any("FAILURE" in c for c in warning_calls)
+
+    def test_success_message_format(self, mock_audit_logger):
+        log_authentication_event("user@test.com", "login", success=True, method="sso")
+
+        info_calls = [
+            str(c) for c in mock_audit_logger.info.call_args_list
+        ]
+        assert any("method: sso" in c for c in info_calls)
+
+
+# ---------------------------------------------------------------------------
+# 3.7  log_permission_check: granted (debug) / denied (warning + JSON)
+# ---------------------------------------------------------------------------
+
+
+class TestLogPermissionCheck:
+    def test_granted_logs_debug(self, mock_audit_logger):
+        log_permission_check(
+            user="user@test.com",
+            permission="chat:query",
+            granted=True,
+            endpoint="/chat",
+            roles=["base-user"],
+        )
+
+        mock_audit_logger.debug.assert_called()
+        debug_msg = str(mock_audit_logger.debug.call_args_list[0])
+        assert "GRANTED" in debug_msg
+
+    def test_denied_logs_warning(self, mock_audit_logger):
+        log_permission_check(
+            user="user@test.com",
+            permission="config:modify",
+            granted=False,
+            endpoint="/config",
+            roles=["base-user"],
+            missing=["config:modify"],
+        )
+
+        mock_audit_logger.warning.assert_called()
+        warning_msg = str(mock_audit_logger.warning.call_args_list[0])
+        assert "DENIED" in warning_msg
+
+    def test_denied_includes_structured_json_with_missing(self, mock_audit_logger):
+        log_permission_check(
+            user="user@test.com",
+            permission="config:modify",
+            granted=False,
+            endpoint="/config",
+            roles=["base-user"],
+            missing=["config:modify"],
+        )
+
+        # The structured JSON is logged at info level
+        info_calls = [
+            str(c) for c in mock_audit_logger.info.call_args_list
+        ]
+        # Find the AUDIT JSON entry
+        audit_json_calls = [c for c in info_calls if "AUDIT" in c]
+        assert len(audit_json_calls) > 0
+        # Verify missing_permissions is in the JSON
+        assert any("missing_permissions" in c for c in audit_json_calls)
+
+
+# ---------------------------------------------------------------------------
+# 3.8  log_role_assignment: jwt (info) / default (warning)
+# ---------------------------------------------------------------------------
+
+
+class TestLogRoleAssignment:
+    def test_jwt_assignment_logs_info(self, mock_audit_logger):
+        log_role_assignment(
+            user="user@test.com",
+            roles=["admin"],
+            source="jwt",
+            is_default=False,
+        )
+
+        mock_audit_logger.info.assert_called()
+        info_msg = str(mock_audit_logger.info.call_args_list[0])
+        assert "jwt" in info_msg
+
+    def test_default_assignment_logs_warning(self, mock_audit_logger):
+        log_role_assignment(
+            user="user@test.com",
+            roles=["base-user"],
+            source="default",
+            is_default=True,
+        )
+
+        mock_audit_logger.warning.assert_called()
+        warning_msg = str(mock_audit_logger.warning.call_args_list[0])
+        assert "Default role" in warning_msg or "default" in warning_msg.lower()

--- a/tests/unit/test_rbac_decorators.py
+++ b/tests/unit/test_rbac_decorators.py
@@ -1,0 +1,171 @@
+"""Tests for RBAC decorators — require_permission, require_any_permission, check_sso_required."""
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+from src.utils.rbac.registry import RBACRegistry
+from src.utils.rbac.decorators import (
+    require_permission,
+    require_any_permission,
+    check_sso_required,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared config
+# ---------------------------------------------------------------------------
+
+ROLES = {
+    "base-user": {
+        "description": "Basic",
+        "permissions": ["chat:query"],
+    },
+    "power-user": {
+        "description": "Power user",
+        "inherits": ["base-user"],
+        "permissions": ["config:view", "config:modify"],
+    },
+    "admin": {
+        "description": "Full access",
+        "permissions": ["*"],
+    },
+}
+
+CONFIG = {
+    "app_name": "test-app",
+    "default_role": "base-user",
+    "sso": {"allow_anonymous": False},
+    "roles": ROLES,
+    "permissions": {},
+}
+
+ANON_CONFIG = {
+    "app_name": "test-app",
+    "default_role": "base-user",
+    "sso": {"allow_anonymous": True},
+    "roles": ROLES,
+    "permissions": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Flask test app + client
+# ---------------------------------------------------------------------------
+
+
+def _create_app(registry):
+    """Build a minimal Flask app with decorated test routes."""
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+
+    @app.route("/login")
+    def login():
+        return "login page", 200
+
+    @app.route("/need-perm")
+    @require_permission("config:view")
+    def need_perm():
+        return "ok", 200
+
+    @app.route("/need-any")
+    @require_any_permission(["config:view", "config:modify"])
+    def need_any():
+        return "ok", 200
+
+    @app.route("/sso-gate")
+    @check_sso_required()
+    def sso_gate():
+        return "ok", 200
+
+    return app
+
+
+@pytest.fixture
+def _registry():
+    return RBACRegistry(CONFIG)
+
+
+@pytest.fixture
+def client(_registry):
+    app = _create_app(_registry)
+    with patch("src.utils.rbac.decorators.get_registry", return_value=_registry):
+        with app.test_client() as c:
+            yield c
+
+
+# ---------------------------------------------------------------------------
+# 4.5  require_permission
+# ---------------------------------------------------------------------------
+
+
+class TestRequirePermission:
+    def test_authenticated_with_permission(self, client):
+        with client.session_transaction() as sess:
+            sess["logged_in"] = True
+            sess["roles"] = ["power-user"]
+            sess["user"] = {"email": "user@test.com"}
+
+        resp = client.get("/need-perm", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200
+
+    def test_authenticated_without_permission(self, client):
+        with client.session_transaction() as sess:
+            sess["logged_in"] = True
+            sess["roles"] = ["base-user"]
+            sess["user"] = {"email": "user@test.com"}
+
+        resp = client.get("/need-perm", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "required_permissions" in data
+
+    def test_unauthenticated_api_request(self, client):
+        resp = client.get("/need-perm", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 4.6  require_any_permission
+# ---------------------------------------------------------------------------
+
+
+class TestRequireAnyPermission:
+    def test_has_one_of_listed(self, client):
+        with client.session_transaction() as sess:
+            sess["logged_in"] = True
+            sess["roles"] = ["power-user"]
+            sess["user"] = {"email": "user@test.com"}
+
+        resp = client.get("/need-any", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 200
+
+    def test_has_none_of_listed(self, client):
+        with client.session_transaction() as sess:
+            sess["logged_in"] = True
+            sess["roles"] = ["base-user"]
+            sess["user"] = {"email": "user@test.com"}
+
+        resp = client.get("/need-any", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 4.7  check_sso_required
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSsoRequired:
+    def test_anonymous_allowed(self):
+        """When allow_anonymous is True, unauthenticated requests pass through."""
+        anon_registry = RBACRegistry(ANON_CONFIG)
+        app = _create_app(anon_registry)
+        with patch("src.utils.rbac.decorators.get_registry", return_value=anon_registry):
+            with app.test_client() as c:
+                resp = c.get("/sso-gate")
+                assert resp.status_code == 200
+
+    def test_anonymous_not_allowed(self, client):
+        """When allow_anonymous is False and no session, JSON request → 401."""
+        resp = client.get("/sso-gate", headers={"Content-Type": "application/json"})
+        assert resp.status_code == 401

--- a/tests/unit/test_rbac_jwt_parser.py
+++ b/tests/unit/test_rbac_jwt_parser.py
@@ -1,0 +1,102 @@
+"""Tests for JWT role extraction — extract_roles_from_token and get_user_roles."""
+
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+from src.utils.rbac.registry import RBACRegistry
+from src.utils.rbac.jwt_parser import extract_roles_from_token, get_user_roles
+
+
+# ---------------------------------------------------------------------------
+# Shared config + registry
+# ---------------------------------------------------------------------------
+
+ROLES = {
+    "admin": {"description": "Full access", "permissions": ["*"]},
+    "base-user": {"description": "Basic", "permissions": ["chat:query"]},
+}
+
+CONFIG = {
+    "app_name": "test-app",
+    "default_role": "base-user",
+    "sso": {"allow_anonymous": False},
+    "roles": ROLES,
+    "permissions": {},
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_registry():
+    registry = RBACRegistry(CONFIG)
+    with patch("src.utils.rbac.jwt_parser.get_registry", return_value=registry):
+        yield registry
+
+
+# ---------------------------------------------------------------------------
+# 4.2  extract_roles_from_token
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRolesFromToken:
+    def test_roles_in_resource_access(self):
+        token = {
+            "resource_access": {
+                "test-app": {"roles": ["admin", "base-user"]}
+            }
+        }
+        assert extract_roles_from_token(token) == ["admin", "base-user"]
+
+    def test_no_resource_access(self):
+        token = {"sub": "user@test.com"}
+        assert extract_roles_from_token(token) == []
+
+    def test_wrong_app_name(self):
+        token = {
+            "resource_access": {
+                "other-app": {"roles": ["admin"]}
+            }
+        }
+        assert extract_roles_from_token(token) == []
+
+    def test_id_token_fallback(self):
+        """When access_token has no resource_access, roles come from id_token."""
+        access_payload = {"sub": "user@test.com"}
+        id_payload = {
+            "sub": "user@test.com",
+            "resource_access": {
+                "test-app": {"roles": ["admin"]}
+            },
+        }
+        token = {
+            "access_token": pyjwt.encode(access_payload, "secret", algorithm="HS256"),
+            "id_token": pyjwt.encode(id_payload, "secret", algorithm="HS256"),
+        }
+        assert extract_roles_from_token(token) == ["admin"]
+
+
+# ---------------------------------------------------------------------------
+# 4.3  get_user_roles
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserRoles:
+    @patch("src.utils.rbac.jwt_parser.log_role_assignment")
+    def test_valid_roles_returned(self, _mock_log):
+        token = {
+            "resource_access": {
+                "test-app": {"roles": ["admin", "base-user"]}
+            }
+        }
+        result = get_user_roles(token, "user@test.com")
+        assert result == ["admin", "base-user"]
+
+    @patch("src.utils.rbac.jwt_parser.log_role_assignment")
+    def test_no_valid_roles_returns_default(self, _mock_log):
+        token = {
+            "resource_access": {
+                "test-app": {"roles": ["unknown-role"]}
+            }
+        }
+        result = get_user_roles(token, "user@test.com")
+        assert result == ["base-user"]

--- a/tests/unit/test_rbac_permissions.py
+++ b/tests/unit/test_rbac_permissions.py
@@ -1,0 +1,90 @@
+"""Tests for RBAC permission utilities — has_permission, is_admin, is_expert with explicit roles."""
+
+from unittest.mock import patch
+
+import pytest
+from src.utils.rbac.registry import RBACRegistry
+from src.utils.rbac.permissions import has_permission, is_admin, is_expert
+
+
+# ---------------------------------------------------------------------------
+# Shared config + mock registry
+# ---------------------------------------------------------------------------
+
+ROLES = {
+    "base-user": {
+        "description": "Basic user",
+        "permissions": ["chat:query", "chat:history"],
+    },
+    "power-user": {
+        "description": "Power user",
+        "inherits": ["base-user"],
+        "permissions": ["upload:documents", "config:modify"],
+    },
+    "admin": {
+        "description": "Full access",
+        "inherits": ["power-user"],
+        "permissions": ["*"],
+    },
+}
+
+CONFIG = {
+    "app_name": "test-app",
+    "default_role": "base-user",
+    "sso": {"allow_anonymous": False},
+    "roles": ROLES,
+    "permissions": {},
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_registry():
+    """Patch get_registry in the permissions module to return a test registry."""
+    registry = RBACRegistry(CONFIG)
+    with patch("src.utils.rbac.permissions.get_registry", return_value=registry):
+        yield registry
+
+
+# ---------------------------------------------------------------------------
+# 3.2  has_permission: granted / denied / empty roles
+# ---------------------------------------------------------------------------
+
+
+class TestHasPermission:
+    def test_granted(self):
+        assert has_permission("chat:query", roles=["base-user"]) is True
+
+    def test_denied(self):
+        assert has_permission("config:modify", roles=["base-user"]) is False
+
+    def test_empty_roles(self):
+        assert has_permission("chat:query", roles=[]) is False
+
+
+# ---------------------------------------------------------------------------
+# 3.3  is_admin: wildcard role / non-admin
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdmin:
+    def test_admin_with_wildcard(self):
+        assert is_admin(roles=["admin"]) is True
+
+    def test_non_admin(self):
+        assert is_admin(roles=["base-user"]) is False
+
+
+# ---------------------------------------------------------------------------
+# 3.4  is_expert: via config:modify / via admin / non-expert
+# ---------------------------------------------------------------------------
+
+
+class TestIsExpert:
+    def test_expert_via_config_modify(self):
+        assert is_expert(roles=["power-user"]) is True
+
+    def test_expert_via_admin(self):
+        assert is_expert(roles=["admin"]) is True
+
+    def test_non_expert(self):
+        assert is_expert(roles=["base-user"]) is False

--- a/tests/unit/test_rbac_registry.py
+++ b/tests/unit/test_rbac_registry.py
@@ -1,0 +1,154 @@
+"""Tests for RBACRegistry — permission resolution, config validation, filtering, and properties."""
+
+import pytest
+from src.utils.rbac.registry import RBACRegistry, RBACConfigError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: inline config dicts
+# ---------------------------------------------------------------------------
+
+def _make_config(
+    roles,
+    default_role="base-user",
+    app_name="test-app",
+    allow_anonymous=False,
+    pass_descriptions_to_agent=False,
+):
+    """Build a minimal valid config dict for RBACRegistry."""
+    return {
+        "app_name": app_name,
+        "default_role": default_role,
+        "sso": {"allow_anonymous": allow_anonymous},
+        "pass_descriptions_to_agent": pass_descriptions_to_agent,
+        "roles": roles,
+        "permissions": {},
+    }
+
+
+BASIC_ROLES = {
+    "base-user": {
+        "description": "Basic authenticated user",
+        "permissions": ["chat:query", "chat:history"],
+    },
+    "power-user": {
+        "description": "Power user with uploads",
+        "inherits": ["base-user"],
+        "permissions": ["upload:documents"],
+    },
+    "admin": {
+        "description": "Full access",
+        "inherits": ["power-user"],
+        "permissions": ["*"],
+    },
+}
+
+
+@pytest.fixture
+def registry():
+    """Registry built from BASIC_ROLES — covers direct, inherited, and wildcard perms."""
+    return RBACRegistry(_make_config(BASIC_ROLES))
+
+
+# ---------------------------------------------------------------------------
+# 2.2  Permission resolution: direct, inherited, multi-level
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionResolution:
+    def test_direct_permission_grant(self, registry):
+        assert registry.has_permission(["base-user"], "chat:query") is True
+
+    def test_permission_via_inheritance(self, registry):
+        """power-user inherits base-user → gets chat:query."""
+        assert registry.has_permission(["power-user"], "chat:query") is True
+
+    def test_direct_permission_on_child(self, registry):
+        """power-user's own permission."""
+        assert registry.has_permission(["power-user"], "upload:documents") is True
+
+    def test_multi_level_inheritance(self, registry):
+        """admin inherits power-user inherits base-user → gets chat:query."""
+        assert registry.has_permission(["admin"], "chat:query") is True
+
+    # ------------------------------------------------------------------
+    # 2.3  Wildcard grants all, permission not granted
+    # ------------------------------------------------------------------
+
+    def test_wildcard_grants_any_permission(self, registry):
+        assert registry.has_permission(["admin"], "any:permission") is True
+
+    def test_permission_not_granted(self, registry):
+        assert registry.has_permission(["base-user"], "upload:documents") is False
+
+
+# ---------------------------------------------------------------------------
+# 2.4  Config validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_circular_inheritance_raises(self):
+        roles = {
+            "a": {"permissions": ["x"], "inherits": ["b"]},
+            "b": {"permissions": ["y"], "inherits": ["a"]},
+        }
+        with pytest.raises(RBACConfigError, match="[Cc]ircular"):
+            RBACRegistry(_make_config(roles, default_role="a"))
+
+    def test_no_roles_raises(self):
+        with pytest.raises(RBACConfigError, match="[Nn]o roles"):
+            RBACRegistry(_make_config(roles={}))
+
+    def test_undefined_parent_raises(self):
+        roles = {
+            "child": {"permissions": ["x"], "inherits": ["nonexistent"]},
+        }
+        with pytest.raises(RBACConfigError, match="undefined role"):
+            RBACRegistry(_make_config(roles, default_role="child"))
+
+
+# ---------------------------------------------------------------------------
+# 2.5  filter_valid_roles
+# ---------------------------------------------------------------------------
+
+
+class TestFilterValidRoles:
+    def test_mixed_valid_and_invalid(self, registry):
+        result = registry.filter_valid_roles(["admin", "unknown-role", "base-user"])
+        assert result == ["admin", "base-user"]
+
+    def test_all_invalid(self, registry):
+        result = registry.filter_valid_roles(["foo", "bar"])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 2.6  Properties: default_role, allow_anonymous, app_name
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryProperties:
+    def test_default_role(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, default_role="base-user"))
+        assert reg.default_role == "base-user"
+
+    def test_default_role_custom(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, default_role="admin"))
+        assert reg.default_role == "admin"
+
+    def test_allow_anonymous_true(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, allow_anonymous=True))
+        assert reg.allow_anonymous is True
+
+    def test_allow_anonymous_false(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, allow_anonymous=False))
+        assert reg.allow_anonymous is False
+
+    def test_app_name_from_config(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, app_name="my-app"))
+        assert reg.app_name == "my-app"
+
+    def test_app_name_override_via_constructor(self):
+        reg = RBACRegistry(_make_config(BASIC_ROLES, app_name="config-app"), app_name="override-app")
+        assert reg.app_name == "override-app"


### PR DESCRIPTION
## Summary

Fixes #552

- Fix 3 pre-existing pyright type errors in `registry.py`, `jwt_parser.py`, and `decorators.py`
- Add 46 unit tests across 5 new test files covering the full RBAC subsystem
- All changes target `src/utils/rbac/` and `tests/unit/test_rbac_*` — no functional behavior changes

## Changes

### Type Fixes (3 files, 10 line changes)
| File | Line | Fix |
|------|------|-----|
| `registry.py:148` | `_resolve_permissions` | `Set[str] = None` → `Optional[Set[str]] = None` |
| `jwt_parser.py:158` | `assign_default_role` | `List[str] = None` → `Optional[List[str]] = None` |
| `decorators.py` | 8 call sites | `request.endpoint` → `request.endpoint or '<unknown>'` |

### New Tests (5 files, 655 lines, 46 tests)
| File | Tests | Covers |
|------|-------|--------|
| `test_rbac_registry.py` | 17 | Permission resolution, inheritance, wildcards, config validation, filtering, properties |
| `test_rbac_permissions.py` | 8 | `has_permission`, `is_admin`, `is_expert` with explicit roles |
| `test_rbac_audit.py` | 8 | Log levels, message format, structured JSON output |
| `test_rbac_jwt_parser.py` | 6 | `extract_roles_from_token` (4 scenarios), `get_user_roles` default fallback |
| `test_rbac_decorators.py` | 7 | `require_permission`, `require_any_permission`, `check_sso_required` via Flask test client |

## Test plan

- [x] `pyright` reports 0 errors on all 3 modified source files
- [x] All 46 new tests pass (`pytest tests/unit/test_rbac_*.py`)
- [x] No changes to RBAC runtime behavior — type annotations and fallback string only

🤖 Generated with [Claude Code](https://claude.com/claude-code)