### PR TITLE
Enable anonymous read-only access to Grafana dashboards

### DIFF
--- a/src/cli/templates/grafana/grafana.ini
+++ b/src/cli/templates/grafana/grafana.ini
@@ -554,13 +554,13 @@
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
-;enabled = false
+enabled = true
 
 # specify organization name that should be used for unauthenticated users
-;org_name = archi
+org_name = Main Org.
 
 # specify role for unauthenticated users
-;org_role = Viewer
+org_role = Viewer
 
 # mask the Grafana version number for unauthenticated users
 ;hide_version = false


### PR DESCRIPTION
## Summary
- Enable Grafana anonymous auth so dashboards are viewable without login
- Anonymous users get `Viewer` role (read-only) in the default org
- No changes to admin or editor access

## Test plan
- [ ] Deploy with `archi deploy` and restart Grafana container
- [ ] Verify dashboard loads without login at `/d/<uid>/archi-usage`
- [ ] Verify anonymous users cannot edit dashboards or settings
- [ ] Verify admin login still works with full permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)