### PR TITLE
Add generic sidecar support for MCP servers

### DIFF
--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -6,8 +6,9 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain.tools import BaseTool
 
-from src.utils.config_access import get_mcp_servers_config
+from src.utils.config_access import get_mcp_servers_config, get_full_config
 from src.utils.logging import get_logger
+from src.archi.pipelines.agents.utils.skill_utils import load_skill
 
 logger = get_logger(__name__)
 
@@ -22,11 +23,23 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     mcp_servers = get_mcp_servers_config()
 
     # Strip archi-only fields that langchain-mcp-adapters doesn't understand.
-    # These are consumed by the compose template (sidecars) or the legacy stdio
-    # install path; the MCP client itself only knows about transport-specific fields.
-    _archi_only_fields = {"env_from_secrets", "host_file_mounts", "build_context", "image", "path"}
+    # These are consumed by the compose template (sidecars), the legacy stdio
+    # install path, or post-load tool customization — the MCP client itself only
+    # knows about transport-specific fields.
+    _archi_only_fields = {
+        "env_from_secrets", "host_file_mounts", "build_context", "image", "path", "skill",
+    }
     client_configs: dict[str, dict] = {}
+    server_skills: dict[str, str] = {}
+    full_config = get_full_config()
     for name, server_cfg in mcp_servers.items():
+        # Load any declared skill so we can append it to this server's tool descriptions.
+        skill_name = server_cfg.get("skill")
+        if skill_name:
+            skill_content = load_skill(skill_name, full_config)
+            if skill_content:
+                server_skills[name] = skill_content
+
         cfg = {k: v for k, v in server_cfg.items() if k not in _archi_only_fields}
         transport = cfg.get("transport")
         if transport == "stdio":
@@ -49,9 +62,14 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     for name in client_configs.keys():
         try:
             tools = await client.get_tools(server_name=name)
+            skill_content = server_skills.get(name)
             for tool in tools:
                 # Return error messages to the LLM instead of crashing the agent chain.
                 tool.handle_tool_error = True
+                if skill_content:
+                    tool.description = (
+                        (tool.description or "") + f"\n--- Domain Knowledge ---\n{skill_content}"
+                    )
                 logger.info(f"Loaded tool from MCP server '{name}': {tool.name} - {tool.description}")
             all_tools.extend(tools)
         except Exception as e:

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 from typing import List, Any, Tuple, Optional
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -19,6 +20,15 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     """
 
     mcp_servers = get_mcp_servers_config()
+
+    # For stdio transport servers, inject the current process environment so that
+    # MCP subprocesses inherit env vars (e.g. RUCIO_HOST, X509_USER_PROXY).
+    # Without this, mcp.client.stdio uses get_default_environment() which only
+    # provides HOME and PATH.
+    for name, server_cfg in mcp_servers.items():
+        if server_cfg.get("transport") == "stdio":
+            server_cfg["env"] = {**os.environ, **(server_cfg.get("env") or {})}
+
     logger.info(f"Configuring MCP client with servers: {list(mcp_servers.keys())}")
     client = MultiServerMCPClient(mcp_servers)
 
@@ -29,6 +39,8 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
         try:
             tools = await client.get_tools(server_name=name)
             for tool in tools:
+                # Return error messages to the LLM instead of crashing the agent chain.
+                tool.handle_tool_error = True
                 logger.info(f"Loaded tool from MCP server '{name}': {tool.name} - {tool.description}")
             all_tools.extend(tools)
         except Exception as e:

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -21,21 +21,32 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
 
     mcp_servers = get_mcp_servers_config()
 
-    # For stdio transport servers, inject the current process environment so that
-    # MCP subprocesses inherit env vars (e.g. RUCIO_HOST, X509_USER_PROXY).
-    # Without this, mcp.client.stdio uses get_default_environment() which only
-    # provides HOME and PATH.
+    # Strip archi-only fields that langchain-mcp-adapters doesn't understand.
+    # These are consumed by the compose template (sidecars) or the legacy stdio
+    # install path; the MCP client itself only knows about transport-specific fields.
+    _archi_only_fields = {"env_from_secrets", "host_file_mounts", "build_context", "image", "path"}
+    client_configs: dict[str, dict] = {}
     for name, server_cfg in mcp_servers.items():
-        if server_cfg.get("transport") == "stdio":
-            server_cfg["env"] = {**os.environ, **(server_cfg.get("env") or {})}
+        cfg = {k: v for k, v in server_cfg.items() if k not in _archi_only_fields}
+        transport = cfg.get("transport")
+        if transport == "stdio":
+            # stdio subprocesses inherit nothing by default (mcp.client.stdio uses
+            # an empty env). Forward the parent process env so stdio MCP servers see
+            # what they need.
+            cfg["env"] = {**os.environ, **(cfg.get("env") or {})}
+        else:
+            # For HTTP-based transports, `env` is for the sidecar container (compose),
+            # not the MCP client connection — drop it here.
+            cfg.pop("env", None)
+        client_configs[name] = cfg
 
-    logger.info(f"Configuring MCP client with servers: {list(mcp_servers.keys())}")
-    client = MultiServerMCPClient(mcp_servers)
+    logger.info(f"Configuring MCP client with servers: {list(client_configs.keys())}")
+    client = MultiServerMCPClient(client_configs)
 
     all_tools: List[BaseTool] = []
     failed_servers: dict[str, str] = {}
 
-    for name in mcp_servers.keys():
+    for name in client_configs.keys():
         try:
             tools = await client.get_tools(server_name=name)
             for tool in tools:
@@ -47,7 +58,7 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
             logger.error(f"Failed to fetch tools from MCP server '{name}': {e}")
             failed_servers[name] = str(e)
 
-    logger.info(f"Active MCP servers: {[n for n in mcp_servers if n not in failed_servers]}")
+    logger.info(f"Active MCP servers: {[n for n in client_configs if n not in failed_servers]}")
     logger.warning(f"Failed MCP servers: {list(failed_servers.keys())}")
 
     return client, all_tools

--- a/src/bin/service_chat.py
+++ b/src/bin/service_chat.py
@@ -20,51 +20,6 @@ def main():
     os.environ['OPENAI_API_KEY'] = read_secret("OPENAI_API_KEY")
     os.environ['HUGGING_FACE_HUB_TOKEN'] = read_secret("HUGGING_FACE_HUB_TOKEN")
 
-    # Resolve Rucio values from *_FILE secrets so MCP child processes inherit concrete env vars.
-    for key in [
-        "RUCIO_HOST",
-        "RUCIO_AUTH_HOST",
-        "RUCIO_ACCOUNT",
-        "RUCIO_AUTH_TYPE",
-        "RUCIO_TIMEOUT",
-        "RUCIO_VO",
-        "RUCIO_CA_CERT",
-        "RUCIO_CLIENT_CERT",
-        "RUCIO_CLIENT_KEY",
-        "RUCIO_CLIENT_PROXY",
-        "X509_USER_PROXY",
-        "RUCIO_CREDS_JSON",
-    ]:
-        value = read_secret(key)
-        if value:
-            os.environ[key] = value
-
-    # X509 proxy vars need special handling: the rucio client expects a *file path*
-    # pointing to PEM content, not the PEM text itself.
-    # The secret file may contain either:
-    #   a) A path string (e.g. /tmp/x509up_u1000) — use that path directly
-    #   b) Actual PEM content — use the secret file path itself
-    for key in ["RUCIO_CLIENT_PROXY", "X509_USER_PROXY"]:
-        value = os.environ.get(key, "")
-        if value and os.path.isfile(value):
-            # Already set to a valid file path (e.g. from read_secret or env)
-            continue
-        file_env = f"{key}_FILE"
-        secret_path = os.getenv(file_env)
-        if secret_path and os.path.isfile(secret_path) and os.path.getsize(secret_path) > 0:
-            content = open(secret_path).read().strip()
-            if os.path.isfile(content):
-                # Secret contains a path to the actual proxy file
-                os.environ[key] = content
-            else:
-                # Secret contains PEM content directly; point rucio at the secret file
-                os.environ[key] = secret_path
-
-    # Generate a minimal rucio.cfg so the Rucio client library doesn't raise
-    # ConfigNotFound.  All actual connection params are passed programmatically by
-    # rucio-mcp, but the library unconditionally requires a config file to exist.
-    _generate_rucio_cfg()
-
     # Set up shared Postgres services (expects config already in DB)
     factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASSWORD"))
     PostgresServiceFactory.set_instance(factory)
@@ -82,34 +37,6 @@ def main():
         static_folder=chat_config["static_folder"],
     ))
     app.run(debug=True, use_reloader=False, port=chat_config["port"], host=chat_config["host"])
-
-
-def _generate_rucio_cfg():
-    """Write a minimal rucio.cfg from env vars so the Rucio client library can load."""
-    rucio_host = os.environ.get("RUCIO_HOST", "")
-    if not rucio_host:
-        return  # Rucio not configured; skip
-
-    import configparser
-    cfg = configparser.ConfigParser()
-    cfg["client"] = {
-        "rucio_host": rucio_host,
-        "auth_host": os.environ.get("RUCIO_AUTH_HOST", ""),
-        "account": os.environ.get("RUCIO_ACCOUNT", ""),
-        "auth_type": os.environ.get("RUCIO_AUTH_TYPE", "x509_proxy"),
-    }
-    ca_cert = os.environ.get("RUCIO_CA_CERT", "")
-    if ca_cert:
-        cfg["client"]["ca_cert"] = ca_cert
-    proxy = os.environ.get("X509_USER_PROXY", "") or os.environ.get("RUCIO_CLIENT_PROXY", "")
-    if proxy:
-        cfg["client"]["client_x509_proxy"] = proxy
-
-    cfg_path = "/tmp/rucio.cfg"
-    with open(cfg_path, "w") as f:
-        cfg.write(f)
-    os.environ["RUCIO_CONFIG"] = cfg_path
-    print(f"Generated Rucio config at {cfg_path}")
 
 
 def generate_script(chat_config):

--- a/src/bin/service_chat.py
+++ b/src/bin/service_chat.py
@@ -20,6 +20,51 @@ def main():
     os.environ['OPENAI_API_KEY'] = read_secret("OPENAI_API_KEY")
     os.environ['HUGGING_FACE_HUB_TOKEN'] = read_secret("HUGGING_FACE_HUB_TOKEN")
 
+    # Resolve Rucio values from *_FILE secrets so MCP child processes inherit concrete env vars.
+    for key in [
+        "RUCIO_HOST",
+        "RUCIO_AUTH_HOST",
+        "RUCIO_ACCOUNT",
+        "RUCIO_AUTH_TYPE",
+        "RUCIO_TIMEOUT",
+        "RUCIO_VO",
+        "RUCIO_CA_CERT",
+        "RUCIO_CLIENT_CERT",
+        "RUCIO_CLIENT_KEY",
+        "RUCIO_CLIENT_PROXY",
+        "X509_USER_PROXY",
+        "RUCIO_CREDS_JSON",
+    ]:
+        value = read_secret(key)
+        if value:
+            os.environ[key] = value
+
+    # X509 proxy vars need special handling: the rucio client expects a *file path*
+    # pointing to PEM content, not the PEM text itself.
+    # The secret file may contain either:
+    #   a) A path string (e.g. /tmp/x509up_u1000) — use that path directly
+    #   b) Actual PEM content — use the secret file path itself
+    for key in ["RUCIO_CLIENT_PROXY", "X509_USER_PROXY"]:
+        value = os.environ.get(key, "")
+        if value and os.path.isfile(value):
+            # Already set to a valid file path (e.g. from read_secret or env)
+            continue
+        file_env = f"{key}_FILE"
+        secret_path = os.getenv(file_env)
+        if secret_path and os.path.isfile(secret_path) and os.path.getsize(secret_path) > 0:
+            content = open(secret_path).read().strip()
+            if os.path.isfile(content):
+                # Secret contains a path to the actual proxy file
+                os.environ[key] = content
+            else:
+                # Secret contains PEM content directly; point rucio at the secret file
+                os.environ[key] = secret_path
+
+    # Generate a minimal rucio.cfg so the Rucio client library doesn't raise
+    # ConfigNotFound.  All actual connection params are passed programmatically by
+    # rucio-mcp, but the library unconditionally requires a config file to exist.
+    _generate_rucio_cfg()
+
     # Set up shared Postgres services (expects config already in DB)
     factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASSWORD"))
     PostgresServiceFactory.set_instance(factory)
@@ -37,6 +82,34 @@ def main():
         static_folder=chat_config["static_folder"],
     ))
     app.run(debug=True, use_reloader=False, port=chat_config["port"], host=chat_config["host"])
+
+
+def _generate_rucio_cfg():
+    """Write a minimal rucio.cfg from env vars so the Rucio client library can load."""
+    rucio_host = os.environ.get("RUCIO_HOST", "")
+    if not rucio_host:
+        return  # Rucio not configured; skip
+
+    import configparser
+    cfg = configparser.ConfigParser()
+    cfg["client"] = {
+        "rucio_host": rucio_host,
+        "auth_host": os.environ.get("RUCIO_AUTH_HOST", ""),
+        "account": os.environ.get("RUCIO_ACCOUNT", ""),
+        "auth_type": os.environ.get("RUCIO_AUTH_TYPE", "x509_proxy"),
+    }
+    ca_cert = os.environ.get("RUCIO_CA_CERT", "")
+    if ca_cert:
+        cfg["client"]["ca_cert"] = ca_cert
+    proxy = os.environ.get("X509_USER_PROXY", "") or os.environ.get("RUCIO_CLIENT_PROXY", "")
+    if proxy:
+        cfg["client"]["client_x509_proxy"] = proxy
+
+    cfg_path = "/tmp/rucio.cfg"
+    with open(cfg_path, "w") as f:
+        cfg.write(f)
+    os.environ["RUCIO_CONFIG"] = cfg_path
+    print(f"Generated Rucio config at {cfg_path}")
 
 
 def generate_script(chat_config):

--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -482,19 +482,9 @@ class TemplateManager:
             template_vars["rubrics"] = self._get_grader_rubrics(context.config_manager)
 
         # Pass MCP server configs so compose can volume-mount stdio packages
+        # and emit sidecar services for servers with build_context/image.
         mcp_servers = context.config_manager.config.get("mcp_servers", {}) or {}
         template_vars["mcp_servers"] = mcp_servers
-
-        # Mount host files (e.g. CA certs, X509 proxy) into the container
-        host_file_mounts = []
-        for env_key in ["RUCIO_CA_CERT", "X509_USER_PROXY"]:
-            try:
-                path = context.secrets_manager.get_secret(env_key)
-                if path and os.path.isfile(path):
-                    host_file_mounts.append(path)
-            except (KeyError, Exception):
-                pass
-        template_vars["host_file_mounts"] = host_file_mounts
 
         compose_template = self.env.get_template(BASE_COMPOSE_TEMPLATE)
         compose_rendered = compose_template.render(**template_vars)

--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -481,6 +481,21 @@ class TemplateManager:
         if context.plan.get_service("grader").enabled:
             template_vars["rubrics"] = self._get_grader_rubrics(context.config_manager)
 
+        # Pass MCP server configs so compose can volume-mount stdio packages
+        mcp_servers = context.config_manager.config.get("mcp_servers", {}) or {}
+        template_vars["mcp_servers"] = mcp_servers
+
+        # Mount host files (e.g. CA certs, X509 proxy) into the container
+        host_file_mounts = []
+        for env_key in ["RUCIO_CA_CERT", "X509_USER_PROXY"]:
+            try:
+                path = context.secrets_manager.get_secret(env_key)
+                if path and os.path.isfile(path):
+                    host_file_mounts.append(path)
+            except (KeyError, Exception):
+                pass
+        template_vars["host_file_mounts"] = host_file_mounts
+
         compose_template = self.env.get_template(BASE_COMPOSE_TEMPLATE)
         compose_rendered = compose_template.render(**template_vars)
 

--- a/src/cli/templates/base-compose.yaml
+++ b/src/cli/templates/base-compose.yaml
@@ -675,6 +675,51 @@ services:
     {%- endif %}
   {%- endif %}
 
+  {#- MCP sidecar services: any mcp_server with build_context or image becomes its own container #}
+  {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+  {%- if srv_cfg.build_context is defined or srv_cfg.image is defined %}
+  {{ srv_name }}-mcp:
+    container_name: {{ srv_name }}-mcp-{{ name }}
+    {%- if srv_cfg.build_context is defined %}
+    build: {{ srv_cfg.build_context }}
+    {%- else %}
+    image: {{ srv_cfg.image }}
+    {%- endif %}
+    {%- if srv_cfg.env or srv_cfg.env_from_secrets %}
+    environment:
+      {%- for k, v in (srv_cfg.env | default({})).items() %}
+      {{ k }}: "{{ v }}"
+      {%- endfor %}
+      {%- for k in srv_cfg.env_from_secrets | default([]) %}
+      {{ k }}_FILE: /run/secrets/{{ k | lower }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if srv_cfg.env_from_secrets %}
+    secrets:
+      {%- for k in srv_cfg.env_from_secrets %}
+      - {{ k | lower }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if srv_cfg.host_file_mounts %}
+    volumes:
+      {%- for m in srv_cfg.host_file_mounts %}
+      {%- if m is string %}
+      - {{ m }}:{{ m }}:ro
+      {%- else %}
+      - {{ m.src }}:{{ m.dest }}:ro
+      {%- endif %}
+      {%- endfor %}
+    {%- endif %}
+    logging:
+      options:
+        max-size: 10m
+    restart: on-failure
+    {%- if host_mode %}
+    network_mode: host
+    {%- endif %}
+  {%- endif %}
+  {%- endfor %}
+
 
 volumes:
   {% for volume in required_volumes -%}

--- a/src/cli/templates/base-compose.yaml
+++ b/src/cli/templates/base-compose.yaml
@@ -168,6 +168,33 @@ services:
       {% if gpu_ids -%}
       - archi-models:/root/models/
       {%- endif %}
+      {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+      {%- if srv_cfg.transport == 'stdio' and srv_cfg.path is defined %}
+      - {{ srv_cfg.path }}:/root/mcp-packages/{{ srv_name }}:ro
+      {%- endif %}
+      {%- endfor %}
+      {%- for host_path in (host_file_mounts | default([])) %}
+      - {{ host_path }}:{{ host_path }}:ro
+      {%- endfor %}
+    {#- Build the MCP auto-install command for stdio packages with a path #}
+    {%- set mcp_installs = [] %}
+    {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+    {%- if srv_cfg.transport == 'stdio' and srv_cfg.path is defined %}
+    {%- set _ = mcp_installs.append(srv_name) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- if mcp_installs %}
+    command:
+      - bash
+      - -lc
+      - >-
+        {%- for srv_name in mcp_installs %}
+        cp -r "/root/mcp-packages/{{ srv_name }}" "/tmp/mcp-build-{{ srv_name }}" &&
+        python -m pip install "/tmp/mcp-build-{{ srv_name }}" &&
+        rm -rf "/tmp/mcp-build-{{ srv_name }}";
+        {%- endfor %}
+        exec python -u src/bin/service_chat.py
+    {%- endif %}
     logging:
       options:
         max-size: 10m

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -14,7 +14,18 @@ mcp_servers:
   {%- for server_name, server_config in (mcp_servers | default({}, true)).items() %}
   {{ server_name }}:
     transport: {{ server_config.transport | default('streamable_http', true) }}
-    url: {{ server_config.url | default('', true) }}
+    {%- if server_config.url is defined %}
+    url: {{ server_config.url }}
+    {%- endif %}
+    {%- if server_config.command is defined %}
+    command: {{ server_config.command }}
+    {%- endif %}
+    {%- if server_config.args is defined %}
+    args: {{ server_config.args | tojson }}
+    {%- endif %}
+    {%- if server_config.env is defined %}
+    env: {{ server_config.env | tojson }}
+    {%- endif %}
   {%- endfor %}
 
 services:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -38,6 +38,9 @@ mcp_servers:
     {%- if server_config.image is defined %}
     image: {{ server_config.image }}
     {%- endif %}
+    {%- if server_config.skill is defined %}
+    skill: {{ server_config.skill }}
+    {%- endif %}
   {%- endfor %}
 
 services:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -26,6 +26,18 @@ mcp_servers:
     {%- if server_config.env is defined %}
     env: {{ server_config.env | tojson }}
     {%- endif %}
+    {%- if server_config.env_from_secrets is defined %}
+    env_from_secrets: {{ server_config.env_from_secrets | tojson }}
+    {%- endif %}
+    {%- if server_config.host_file_mounts is defined %}
+    host_file_mounts: {{ server_config.host_file_mounts | tojson }}
+    {%- endif %}
+    {%- if server_config.build_context is defined %}
+    build_context: {{ server_config.build_context }}
+    {%- endif %}
+    {%- if server_config.image is defined %}
+    image: {{ server_config.image }}
+    {%- endif %}
   {%- endfor %}
 
 services:


### PR DESCRIPTION

### Summary

Adds first-class support for MCP servers that run as their own Docker containers (sidecars), communicating with the chatbot over HTTP. Previously only stdio MCP servers (running in-process) and external HTTP MCP servers were supported. This lets tool-specific MCP servers ship their own dependencies, credentials, and setup logic in their own repo — without any archi-side code.

### Motivation

CMS CompOps needs a Rucio MCP server that requires heavy dependencies (`rucio-clients`, `voms-clients-java`), credential handling (X509 proxies), and a Rucio config file. Shoving all that into the chatbot container would couple archi to one specific tool. A generic sidecar pattern solves it once for every future tool.

### Changes

Four files, all generic — no tool-specific strings:

- **`base-config.yaml`** — render four new optional MCP server fields: `build_context`, `image`, `env_from_secrets`, `host_file_mounts`
- **`base-compose.yaml`** — when an MCP server declares `build_context` or `image`, emit a compose service for it with the declared env vars, secrets, and host file mounts (supports asymmetric `src → dest` mount form)
- **`templates_manager.py`** — pass the `mcp_servers` config through to the compose template (one-line addition)
- **`mcp.py`** — strip archi-only fields (`build_context`, `host_file_mounts`, etc.) before passing config to `MultiServerMCPClient`, which only knows about transport-specific fields

### New deployment config schema

```yaml
mcp_servers:
  rucio:
    transport: streamable_http
    url: http://localhost:8000/mcp
    build_context: /path/to/rucio-mcp
    env:
      RUCIO_HOST: http://cms-rucio-int.cern.ch
      # ... plain config, checked in
    env_from_secrets: []       # Docker secrets
    host_file_mounts:
      - /etc/pki/tls/certs/CERN-bundle.pem
      - src: /tmp/x509up_u1000
        dest: /tmp/x509up
```

### What this enables

Adding a new MCP server becomes a 3-step recipe with zero archi framework changes:

1. Write the MCP server in its own repo with HTTP transport + Dockerfile such as https://github.com/haozturk/rucio-mcp
2. Declare it in the deployment config with `build_context` + any env/mounts it needs
3. Restart