### PR TITLE
Generic MCP sidecar + domain-knowledge skills + tool-use observability

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -55,6 +55,7 @@ class BaseReActAgent:
         self._active_memory: Optional[RunMemory] = None
         self._static_tools: Optional[List[Callable]] = None
         self._mcp_tools: Optional[List[Callable]] = None
+        self._mcp_skills_text: str = ""
         self._active_tools: List[Callable] = []
         self._static_middleware: Optional[List[Callable]] = None
         self._active_middleware: List[Callable] = []
@@ -134,10 +135,14 @@ class BaseReActAgent:
         # Different providers use different keys
         usage = response_metadata.get("usage") or response_metadata.get("token_usage")
         if usage:
+            # OpenAI nests cache info under prompt_tokens_details.cached_tokens.
+            details = usage.get("prompt_tokens_details") or {}
+            cached_tokens = details.get("cached_tokens", 0) if isinstance(details, dict) else 0
             return {
                 "prompt_tokens": usage.get("prompt_tokens") or usage.get("input_tokens", 0),
                 "completion_tokens": usage.get("completion_tokens") or usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "cached_tokens": int(cached_tokens or 0),
             }
         # Ollama format
         if "prompt_eval_count" in response_metadata or "eval_count" in response_metadata:
@@ -147,6 +152,7 @@ class BaseReActAgent:
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
+                "cached_tokens": 0,
             }
         return None
 
@@ -179,7 +185,7 @@ class BaseReActAgent:
     def _extract_usage_from_messages(self, messages: List[BaseMessage]) -> Optional[Dict[str, int]]:
         """
         Sum token usage across ALL AI messages in the turn.
-        
+
         In a multi-step agent loop, the LLM is called multiple times
         (thinking, tool decisions, final answer). Each call reports its
         own prompt_tokens and completion_tokens. We sum them to show
@@ -187,8 +193,9 @@ class BaseReActAgent:
         """
         total_prompt = 0
         total_completion = 0
+        total_cached = 0
         found_any = False
-        
+
         for msg in messages:
             msg_type = str(getattr(msg, "type", "")).lower()
             if msg_type not in {"ai", "assistant"} and "ai" not in type(msg).__name__.lower():
@@ -197,15 +204,17 @@ class BaseReActAgent:
             if usage:
                 total_prompt += usage.get("prompt_tokens", 0)
                 total_completion += usage.get("completion_tokens", 0)
+                total_cached += usage.get("cached_tokens", 0)
                 found_any = True
-        
+
         if not found_any:
             return None
-        
+
         return {
             "prompt_tokens": total_prompt,
             "completion_tokens": total_completion,
             "total_tokens": total_prompt + total_completion,
+            "cached_tokens": total_cached,
         }
 
     def _extract_usage_from_message(self, message: BaseMessage) -> Optional[Dict[str, int]]:
@@ -215,11 +224,18 @@ class BaseReActAgent:
             prompt_tokens = usage_metadata.get("input_tokens", 0)
             completion_tokens = usage_metadata.get("output_tokens", 0)
             total_tokens = usage_metadata.get("total_tokens", prompt_tokens + completion_tokens)
+            # LangChain standardizes cache hit info under input_token_details.cache_read.
+            # OpenAI maps prompt_tokens_details.cached_tokens → cache_read here.
+            input_details = usage_metadata.get("input_token_details") or {}
+            cached_tokens = (
+                input_details.get("cache_read", 0) if isinstance(input_details, dict) else 0
+            )
             if prompt_tokens or completion_tokens or total_tokens:
                 return {
                     "prompt_tokens": int(prompt_tokens or 0),
                     "completion_tokens": int(completion_tokens or 0),
                     "total_tokens": int(total_tokens or 0),
+                    "cached_tokens": int(cached_tokens or 0),
                 }
 
         response_metadata = getattr(message, "response_metadata", None)
@@ -538,12 +554,21 @@ class BaseReActAgent:
             usage = self._extract_usage_from_metadata(last_response_metadata)
         if model is None:
             model = self._extract_model_from_metadata(last_response_metadata)
+        if usage:
+            pt = usage.get("prompt_tokens", 0)
+            ct = usage.get("completion_tokens", 0)
+            cached = usage.get("cached_tokens", 0)
+            hit = (cached / pt * 100.0) if pt else 0.0
+            logger.info(
+                "Usage: prompt=%d (cached=%d, %.1f%% hit) completion=%d total=%d",
+                pt, cached, hit, ct, usage.get("total_tokens", pt + ct),
+            )
         final_metadata = {
             "event_type": "final",
             "usage": usage,
             "model": model,
         }
-        
+
         if final_answer:
             yield self.finalize_output(
                 answer=final_answer,
@@ -809,12 +834,21 @@ class BaseReActAgent:
             usage = self._extract_usage_from_metadata(last_response_metadata)
         if model is None:
             model = self._extract_model_from_metadata(last_response_metadata)
+        if usage:
+            pt = usage.get("prompt_tokens", 0)
+            ct = usage.get("completion_tokens", 0)
+            cached = usage.get("cached_tokens", 0)
+            hit = (cached / pt * 100.0) if pt else 0.0
+            logger.info(
+                "Usage: prompt=%d (cached=%d, %.1f%% hit) completion=%d total=%d",
+                pt, cached, hit, ct, usage.get("total_tokens", pt + ct),
+            )
         final_metadata = {
             "event_type": "final",
             "usage": usage,
             "model": model,
         }
-        
+
         if final_answer:
             yield self.finalize_output(
                 answer=final_answer,
@@ -1029,14 +1063,16 @@ class BaseReActAgent:
 
     def _build_system_prompt(self) -> str:
         """
-        Build the full system prompt, appending role context if enabled.
-        
+        Build the full system prompt, appending role context and MCP server skills.
+
         Role context is appended when SSO auth with auth_roles is configured
-        and pass_descriptions_to_agent is set to true.
+        and pass_descriptions_to_agent is set to true. MCP server skills are
+        appended once here rather than per-tool so long skills don't multiply
+        by the number of tools in the catalog.
         """
         base_prompt = self.agent_prompt or ""
         role_context = get_role_context()
-        return base_prompt + role_context
+        return base_prompt + role_context + (self._mcp_skills_text or "")
 
     def _create_agent(self, tools: Sequence[Callable], middleware: Sequence[Callable]) -> CompiledStateGraph:
         """Create the LangGraph agent with the specified LLM, tools, and system prompt."""
@@ -1064,11 +1100,12 @@ class BaseReActAgent:
 
             # Initialize MCP client on the background loop
             # The client and sessions will live on this loop
-            client, mcp_tools = self._async_runner.run(initialize_mcp_client())
+            client, mcp_tools, skills_text = self._async_runner.run(initialize_mcp_client())
             if client is None:
                 logger.info("No MCP servers configured.")
                 return None
             self.mcp_client = client
+            self._mcp_skills_text = skills_text or ""
 
             # Create synchronous wrappers that use the SAME loop
             def make_synchronous(async_tool):

--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -1108,6 +1108,8 @@ class BaseReActAgent:
             self._mcp_skills_text = skills_text or ""
 
             # Create synchronous wrappers that use the SAME loop
+            store_tool_input = self._store_tool_input
+
             def make_synchronous(async_tool):
                 """
                 Wrap an async tool for synchronous execution.
@@ -1119,10 +1121,24 @@ class BaseReActAgent:
                 """
                 # Capture the runner in closure
                 runner = self._async_runner
+                tool_name = async_tool.name
 
                 def sync_wrapper(*args, **kwargs):
                     if runner.in_loop_thread():
                         raise RuntimeError("sync_wrapper called from MCP loop thread; would deadlock")
+                    # Streamed tool_call chunks arrive without args; record here so the UI can resolve them by tool_call_id.
+                    try:
+                        recorded = {
+                            k: v
+                            for k, v in kwargs.items()
+                            if k not in {"config", "run_manager", "callbacks"}
+                        }
+                        if recorded:
+                            store_tool_input(tool_name, recorded)
+                    except Exception as exc:
+                        logger.debug(
+                            "Failed to record MCP tool input for %s: %s", tool_name, exc
+                        )
                     # Run on the background loop - NOT a new loop!
                     return runner.run(async_tool.coroutine(*args, **kwargs))
 

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -6,8 +6,9 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain.tools import BaseTool
 
-from src.utils.config_access import get_mcp_servers_config
+from src.utils.config_access import get_mcp_servers_config, get_full_config
 from src.utils.logging import get_logger
+from src.archi.pipelines.agents.utils.skill_utils import load_skill
 
 logger = get_logger(__name__)
 
@@ -22,11 +23,23 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     mcp_servers = get_mcp_servers_config()
 
     # Strip archi-only fields that langchain-mcp-adapters doesn't understand.
-    # These are consumed by the compose template (sidecars) or the legacy stdio
-    # install path; the MCP client itself only knows about transport-specific fields.
-    _archi_only_fields = {"env_from_secrets", "host_file_mounts", "build_context", "image", "path"}
+    # These are consumed by the compose template (sidecars), the legacy stdio
+    # install path, or post-load tool customization — the MCP client itself only
+    # knows about transport-specific fields.
+    _archi_only_fields = {
+        "env_from_secrets", "host_file_mounts", "build_context", "image", "path", "skill",
+    }
     client_configs: dict[str, dict] = {}
+    server_skills: dict[str, str] = {}
+    full_config = get_full_config()
     for name, server_cfg in mcp_servers.items():
+        # Load any declared skill so we can append it to this server's tool descriptions.
+        skill_name = server_cfg.get("skill")
+        if skill_name:
+            skill_content = load_skill(skill_name, full_config)
+            if skill_content:
+                server_skills[name] = skill_content
+
         cfg = {k: v for k, v in server_cfg.items() if k not in _archi_only_fields}
         transport = cfg.get("transport")
         if transport == "stdio":
@@ -49,9 +62,14 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     for name in client_configs.keys():
         try:
             tools = await client.get_tools(server_name=name)
+            skill_content = server_skills.get(name)
             for tool in tools:
                 # Return error messages to the LLM instead of crashing the agent chain.
                 tool.handle_tool_error = True
+                if skill_content:
+                    tool.description = (
+                        (tool.description or "") + f"\n--- Domain Knowledge ---\n{skill_content}"
+                    )
                 logger.info(f"Loaded tool from MCP server '{name}': {tool.name} - {tool.description}")
             all_tools.extend(tools)
         except Exception as e:

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 from typing import List, Any, Tuple, Optional
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -19,6 +20,15 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     """
 
     mcp_servers = get_mcp_servers_config()
+
+    # For stdio transport servers, inject the current process environment so that
+    # MCP subprocesses inherit env vars (e.g. RUCIO_HOST, X509_USER_PROXY).
+    # Without this, mcp.client.stdio uses get_default_environment() which only
+    # provides HOME and PATH.
+    for name, server_cfg in mcp_servers.items():
+        if server_cfg.get("transport") == "stdio":
+            server_cfg["env"] = {**os.environ, **(server_cfg.get("env") or {})}
+
     logger.info(f"Configuring MCP client with servers: {list(mcp_servers.keys())}")
     client = MultiServerMCPClient(mcp_servers)
 
@@ -29,6 +39,8 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
         try:
             tools = await client.get_tools(server_name=name)
             for tool in tools:
+                # Return error messages to the LLM instead of crashing the agent chain.
+                tool.handle_tool_error = True
                 logger.info(f"Loaded tool from MCP server '{name}': {tool.name} - {tool.description}")
             all_tools.extend(tools)
         except Exception as e:

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -21,21 +21,32 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
 
     mcp_servers = get_mcp_servers_config()
 
-    # For stdio transport servers, inject the current process environment so that
-    # MCP subprocesses inherit env vars (e.g. RUCIO_HOST, X509_USER_PROXY).
-    # Without this, mcp.client.stdio uses get_default_environment() which only
-    # provides HOME and PATH.
+    # Strip archi-only fields that langchain-mcp-adapters doesn't understand.
+    # These are consumed by the compose template (sidecars) or the legacy stdio
+    # install path; the MCP client itself only knows about transport-specific fields.
+    _archi_only_fields = {"env_from_secrets", "host_file_mounts", "build_context", "image", "path"}
+    client_configs: dict[str, dict] = {}
     for name, server_cfg in mcp_servers.items():
-        if server_cfg.get("transport") == "stdio":
-            server_cfg["env"] = {**os.environ, **(server_cfg.get("env") or {})}
+        cfg = {k: v for k, v in server_cfg.items() if k not in _archi_only_fields}
+        transport = cfg.get("transport")
+        if transport == "stdio":
+            # stdio subprocesses inherit nothing by default (mcp.client.stdio uses
+            # an empty env). Forward the parent process env so stdio MCP servers see
+            # what they need.
+            cfg["env"] = {**os.environ, **(cfg.get("env") or {})}
+        else:
+            # For HTTP-based transports, `env` is for the sidecar container (compose),
+            # not the MCP client connection — drop it here.
+            cfg.pop("env", None)
+        client_configs[name] = cfg
 
-    logger.info(f"Configuring MCP client with servers: {list(mcp_servers.keys())}")
-    client = MultiServerMCPClient(mcp_servers)
+    logger.info(f"Configuring MCP client with servers: {list(client_configs.keys())}")
+    client = MultiServerMCPClient(client_configs)
 
     all_tools: List[BaseTool] = []
     failed_servers: dict[str, str] = {}
 
-    for name in mcp_servers.keys():
+    for name in client_configs.keys():
         try:
             tools = await client.get_tools(server_name=name)
             for tool in tools:
@@ -47,7 +58,7 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
             logger.error(f"Failed to fetch tools from MCP server '{name}': {e}")
             failed_servers[name] = str(e)
 
-    logger.info(f"Active MCP servers: {[n for n in mcp_servers if n not in failed_servers]}")
+    logger.info(f"Active MCP servers: {[n for n in client_configs if n not in failed_servers]}")
     logger.warning(f"Failed MCP servers: {list(failed_servers.keys())}")
 
     return client, all_tools

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -12,12 +12,17 @@ from src.archi.pipelines.agents.utils.skill_utils import load_skill
 
 logger = get_logger(__name__)
 
-async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[BaseTool]]:
+async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[BaseTool], str]:
     """
     Initializes the MCP client and fetches tool definitions.
     Returns:
         client: The active client instance (must be kept alive by the caller).
         tools: The list of LangChain-compatible tools.
+        skills_text: Concatenated skill content from all MCP servers that declare
+            a `skill`. Empty string if no server has a skill. The caller is
+            responsible for appending this to the agent's system prompt — we inject
+            here only once per agent rather than into each tool description, so
+            the content doesn't multiply by tool count.
     """
 
     mcp_servers = get_mcp_servers_config()
@@ -62,14 +67,9 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     for name in client_configs.keys():
         try:
             tools = await client.get_tools(server_name=name)
-            skill_content = server_skills.get(name)
             for tool in tools:
                 # Return error messages to the LLM instead of crashing the agent chain.
                 tool.handle_tool_error = True
-                if skill_content:
-                    tool.description = (
-                        (tool.description or "") + f"\n--- Domain Knowledge ---\n{skill_content}"
-                    )
                 logger.info(f"Loaded tool from MCP server '{name}': {tool.name} - {tool.description}")
             all_tools.extend(tools)
         except Exception as e:
@@ -79,4 +79,14 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     logger.info(f"Active MCP servers: {[n for n in client_configs if n not in failed_servers]}")
     logger.warning(f"Failed MCP servers: {list(failed_servers.keys())}")
 
-    return client, all_tools
+    # Build a single combined skills block keyed by server name — this is appended
+    # to the agent's system prompt once, rather than duplicated across every tool.
+    skills_parts: List[str] = []
+    for name, skill_content in server_skills.items():
+        if name not in failed_servers:
+            skills_parts.append(
+                f"\n--- {name} MCP Server Domain Knowledge ---\n{skill_content}"
+            )
+    skills_text = "".join(skills_parts)
+
+    return client, all_tools, skills_text

--- a/src/bin/service_chat.py
+++ b/src/bin/service_chat.py
@@ -20,51 +20,6 @@ def main():
     os.environ['OPENAI_API_KEY'] = read_secret("OPENAI_API_KEY")
     os.environ['HUGGING_FACE_HUB_TOKEN'] = read_secret("HUGGING_FACE_HUB_TOKEN")
 
-    # Resolve Rucio values from *_FILE secrets so MCP child processes inherit concrete env vars.
-    for key in [
-        "RUCIO_HOST",
-        "RUCIO_AUTH_HOST",
-        "RUCIO_ACCOUNT",
-        "RUCIO_AUTH_TYPE",
-        "RUCIO_TIMEOUT",
-        "RUCIO_VO",
-        "RUCIO_CA_CERT",
-        "RUCIO_CLIENT_CERT",
-        "RUCIO_CLIENT_KEY",
-        "RUCIO_CLIENT_PROXY",
-        "X509_USER_PROXY",
-        "RUCIO_CREDS_JSON",
-    ]:
-        value = read_secret(key)
-        if value:
-            os.environ[key] = value
-
-    # X509 proxy vars need special handling: the rucio client expects a *file path*
-    # pointing to PEM content, not the PEM text itself.
-    # The secret file may contain either:
-    #   a) A path string (e.g. /tmp/x509up_u1000) — use that path directly
-    #   b) Actual PEM content — use the secret file path itself
-    for key in ["RUCIO_CLIENT_PROXY", "X509_USER_PROXY"]:
-        value = os.environ.get(key, "")
-        if value and os.path.isfile(value):
-            # Already set to a valid file path (e.g. from read_secret or env)
-            continue
-        file_env = f"{key}_FILE"
-        secret_path = os.getenv(file_env)
-        if secret_path and os.path.isfile(secret_path) and os.path.getsize(secret_path) > 0:
-            content = open(secret_path).read().strip()
-            if os.path.isfile(content):
-                # Secret contains a path to the actual proxy file
-                os.environ[key] = content
-            else:
-                # Secret contains PEM content directly; point rucio at the secret file
-                os.environ[key] = secret_path
-
-    # Generate a minimal rucio.cfg so the Rucio client library doesn't raise
-    # ConfigNotFound.  All actual connection params are passed programmatically by
-    # rucio-mcp, but the library unconditionally requires a config file to exist.
-    _generate_rucio_cfg()
-
     # Set up shared Postgres services (expects config already in DB)
     factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASSWORD"))
     PostgresServiceFactory.set_instance(factory)
@@ -82,34 +37,6 @@ def main():
         static_folder=chat_config["static_folder"],
     ))
     app.run(debug=True, use_reloader=False, port=chat_config["port"], host=chat_config["host"])
-
-
-def _generate_rucio_cfg():
-    """Write a minimal rucio.cfg from env vars so the Rucio client library can load."""
-    rucio_host = os.environ.get("RUCIO_HOST", "")
-    if not rucio_host:
-        return  # Rucio not configured; skip
-
-    import configparser
-    cfg = configparser.ConfigParser()
-    cfg["client"] = {
-        "rucio_host": rucio_host,
-        "auth_host": os.environ.get("RUCIO_AUTH_HOST", ""),
-        "account": os.environ.get("RUCIO_ACCOUNT", ""),
-        "auth_type": os.environ.get("RUCIO_AUTH_TYPE", "x509_proxy"),
-    }
-    ca_cert = os.environ.get("RUCIO_CA_CERT", "")
-    if ca_cert:
-        cfg["client"]["ca_cert"] = ca_cert
-    proxy = os.environ.get("X509_USER_PROXY", "") or os.environ.get("RUCIO_CLIENT_PROXY", "")
-    if proxy:
-        cfg["client"]["client_x509_proxy"] = proxy
-
-    cfg_path = "/tmp/rucio.cfg"
-    with open(cfg_path, "w") as f:
-        cfg.write(f)
-    os.environ["RUCIO_CONFIG"] = cfg_path
-    print(f"Generated Rucio config at {cfg_path}")
 
 
 def generate_script(chat_config):

--- a/src/bin/service_chat.py
+++ b/src/bin/service_chat.py
@@ -20,6 +20,51 @@ def main():
     os.environ['OPENAI_API_KEY'] = read_secret("OPENAI_API_KEY")
     os.environ['HUGGING_FACE_HUB_TOKEN'] = read_secret("HUGGING_FACE_HUB_TOKEN")
 
+    # Resolve Rucio values from *_FILE secrets so MCP child processes inherit concrete env vars.
+    for key in [
+        "RUCIO_HOST",
+        "RUCIO_AUTH_HOST",
+        "RUCIO_ACCOUNT",
+        "RUCIO_AUTH_TYPE",
+        "RUCIO_TIMEOUT",
+        "RUCIO_VO",
+        "RUCIO_CA_CERT",
+        "RUCIO_CLIENT_CERT",
+        "RUCIO_CLIENT_KEY",
+        "RUCIO_CLIENT_PROXY",
+        "X509_USER_PROXY",
+        "RUCIO_CREDS_JSON",
+    ]:
+        value = read_secret(key)
+        if value:
+            os.environ[key] = value
+
+    # X509 proxy vars need special handling: the rucio client expects a *file path*
+    # pointing to PEM content, not the PEM text itself.
+    # The secret file may contain either:
+    #   a) A path string (e.g. /tmp/x509up_u1000) — use that path directly
+    #   b) Actual PEM content — use the secret file path itself
+    for key in ["RUCIO_CLIENT_PROXY", "X509_USER_PROXY"]:
+        value = os.environ.get(key, "")
+        if value and os.path.isfile(value):
+            # Already set to a valid file path (e.g. from read_secret or env)
+            continue
+        file_env = f"{key}_FILE"
+        secret_path = os.getenv(file_env)
+        if secret_path and os.path.isfile(secret_path) and os.path.getsize(secret_path) > 0:
+            content = open(secret_path).read().strip()
+            if os.path.isfile(content):
+                # Secret contains a path to the actual proxy file
+                os.environ[key] = content
+            else:
+                # Secret contains PEM content directly; point rucio at the secret file
+                os.environ[key] = secret_path
+
+    # Generate a minimal rucio.cfg so the Rucio client library doesn't raise
+    # ConfigNotFound.  All actual connection params are passed programmatically by
+    # rucio-mcp, but the library unconditionally requires a config file to exist.
+    _generate_rucio_cfg()
+
     # Set up shared Postgres services (expects config already in DB)
     factory = PostgresServiceFactory.from_env(password_override=read_secret("PG_PASSWORD"))
     PostgresServiceFactory.set_instance(factory)
@@ -37,6 +82,34 @@ def main():
         static_folder=chat_config["static_folder"],
     ))
     app.run(debug=True, use_reloader=False, port=chat_config["port"], host=chat_config["host"])
+
+
+def _generate_rucio_cfg():
+    """Write a minimal rucio.cfg from env vars so the Rucio client library can load."""
+    rucio_host = os.environ.get("RUCIO_HOST", "")
+    if not rucio_host:
+        return  # Rucio not configured; skip
+
+    import configparser
+    cfg = configparser.ConfigParser()
+    cfg["client"] = {
+        "rucio_host": rucio_host,
+        "auth_host": os.environ.get("RUCIO_AUTH_HOST", ""),
+        "account": os.environ.get("RUCIO_ACCOUNT", ""),
+        "auth_type": os.environ.get("RUCIO_AUTH_TYPE", "x509_proxy"),
+    }
+    ca_cert = os.environ.get("RUCIO_CA_CERT", "")
+    if ca_cert:
+        cfg["client"]["ca_cert"] = ca_cert
+    proxy = os.environ.get("X509_USER_PROXY", "") or os.environ.get("RUCIO_CLIENT_PROXY", "")
+    if proxy:
+        cfg["client"]["client_x509_proxy"] = proxy
+
+    cfg_path = "/tmp/rucio.cfg"
+    with open(cfg_path, "w") as f:
+        cfg.write(f)
+    os.environ["RUCIO_CONFIG"] = cfg_path
+    print(f"Generated Rucio config at {cfg_path}")
 
 
 def generate_script(chat_config):

--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -482,19 +482,9 @@ class TemplateManager:
             template_vars["rubrics"] = self._get_grader_rubrics(context.config_manager)
 
         # Pass MCP server configs so compose can volume-mount stdio packages
+        # and emit sidecar services for servers with build_context/image.
         mcp_servers = context.config_manager.config.get("mcp_servers", {}) or {}
         template_vars["mcp_servers"] = mcp_servers
-
-        # Mount host files (e.g. CA certs, X509 proxy) into the container
-        host_file_mounts = []
-        for env_key in ["RUCIO_CA_CERT", "X509_USER_PROXY"]:
-            try:
-                path = context.secrets_manager.get_secret(env_key)
-                if path and os.path.isfile(path):
-                    host_file_mounts.append(path)
-            except (KeyError, Exception):
-                pass
-        template_vars["host_file_mounts"] = host_file_mounts
 
         compose_template = self.env.get_template(BASE_COMPOSE_TEMPLATE)
         compose_rendered = compose_template.render(**template_vars)

--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -481,6 +481,21 @@ class TemplateManager:
         if context.plan.get_service("grader").enabled:
             template_vars["rubrics"] = self._get_grader_rubrics(context.config_manager)
 
+        # Pass MCP server configs so compose can volume-mount stdio packages
+        mcp_servers = context.config_manager.config.get("mcp_servers", {}) or {}
+        template_vars["mcp_servers"] = mcp_servers
+
+        # Mount host files (e.g. CA certs, X509 proxy) into the container
+        host_file_mounts = []
+        for env_key in ["RUCIO_CA_CERT", "X509_USER_PROXY"]:
+            try:
+                path = context.secrets_manager.get_secret(env_key)
+                if path and os.path.isfile(path):
+                    host_file_mounts.append(path)
+            except (KeyError, Exception):
+                pass
+        template_vars["host_file_mounts"] = host_file_mounts
+
         compose_template = self.env.get_template(BASE_COMPOSE_TEMPLATE)
         compose_rendered = compose_template.render(**template_vars)
 

--- a/src/cli/templates/base-compose.yaml
+++ b/src/cli/templates/base-compose.yaml
@@ -675,6 +675,51 @@ services:
     {%- endif %}
   {%- endif %}
 
+  {#- MCP sidecar services: any mcp_server with build_context or image becomes its own container #}
+  {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+  {%- if srv_cfg.build_context is defined or srv_cfg.image is defined %}
+  {{ srv_name }}-mcp:
+    container_name: {{ srv_name }}-mcp-{{ name }}
+    {%- if srv_cfg.build_context is defined %}
+    build: {{ srv_cfg.build_context }}
+    {%- else %}
+    image: {{ srv_cfg.image }}
+    {%- endif %}
+    {%- if srv_cfg.env or srv_cfg.env_from_secrets %}
+    environment:
+      {%- for k, v in (srv_cfg.env | default({})).items() %}
+      {{ k }}: "{{ v }}"
+      {%- endfor %}
+      {%- for k in srv_cfg.env_from_secrets | default([]) %}
+      {{ k }}_FILE: /run/secrets/{{ k | lower }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if srv_cfg.env_from_secrets %}
+    secrets:
+      {%- for k in srv_cfg.env_from_secrets %}
+      - {{ k | lower }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if srv_cfg.host_file_mounts %}
+    volumes:
+      {%- for m in srv_cfg.host_file_mounts %}
+      {%- if m is string %}
+      - {{ m }}:{{ m }}:ro
+      {%- else %}
+      - {{ m.src }}:{{ m.dest }}:ro
+      {%- endif %}
+      {%- endfor %}
+    {%- endif %}
+    logging:
+      options:
+        max-size: 10m
+    restart: on-failure
+    {%- if host_mode %}
+    network_mode: host
+    {%- endif %}
+  {%- endif %}
+  {%- endfor %}
+
 
 volumes:
   {% for volume in required_volumes -%}

--- a/src/cli/templates/base-compose.yaml
+++ b/src/cli/templates/base-compose.yaml
@@ -168,6 +168,33 @@ services:
       {% if gpu_ids -%}
       - archi-models:/root/models/
       {%- endif %}
+      {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+      {%- if srv_cfg.transport == 'stdio' and srv_cfg.path is defined %}
+      - {{ srv_cfg.path }}:/root/mcp-packages/{{ srv_name }}:ro
+      {%- endif %}
+      {%- endfor %}
+      {%- for host_path in (host_file_mounts | default([])) %}
+      - {{ host_path }}:{{ host_path }}:ro
+      {%- endfor %}
+    {#- Build the MCP auto-install command for stdio packages with a path #}
+    {%- set mcp_installs = [] %}
+    {%- for srv_name, srv_cfg in (mcp_servers | default({})).items() %}
+    {%- if srv_cfg.transport == 'stdio' and srv_cfg.path is defined %}
+    {%- set _ = mcp_installs.append(srv_name) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- if mcp_installs %}
+    command:
+      - bash
+      - -lc
+      - >-
+        {%- for srv_name in mcp_installs %}
+        cp -r "/root/mcp-packages/{{ srv_name }}" "/tmp/mcp-build-{{ srv_name }}" &&
+        python -m pip install "/tmp/mcp-build-{{ srv_name }}" &&
+        rm -rf "/tmp/mcp-build-{{ srv_name }}";
+        {%- endfor %}
+        exec python -u src/bin/service_chat.py
+    {%- endif %}
     logging:
       options:
         max-size: 10m

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -14,7 +14,18 @@ mcp_servers:
   {%- for server_name, server_config in (mcp_servers | default({}, true)).items() %}
   {{ server_name }}:
     transport: {{ server_config.transport | default('streamable_http', true) }}
-    url: {{ server_config.url | default('', true) }}
+    {%- if server_config.url is defined %}
+    url: {{ server_config.url }}
+    {%- endif %}
+    {%- if server_config.command is defined %}
+    command: {{ server_config.command }}
+    {%- endif %}
+    {%- if server_config.args is defined %}
+    args: {{ server_config.args | tojson }}
+    {%- endif %}
+    {%- if server_config.env is defined %}
+    env: {{ server_config.env | tojson }}
+    {%- endif %}
   {%- endfor %}
 
 services:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -38,6 +38,9 @@ mcp_servers:
     {%- if server_config.image is defined %}
     image: {{ server_config.image }}
     {%- endif %}
+    {%- if server_config.skill is defined %}
+    skill: {{ server_config.skill }}
+    {%- endif %}
   {%- endfor %}
 
 services:

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -26,6 +26,18 @@ mcp_servers:
     {%- if server_config.env is defined %}
     env: {{ server_config.env | tojson }}
     {%- endif %}
+    {%- if server_config.env_from_secrets is defined %}
+    env_from_secrets: {{ server_config.env_from_secrets | tojson }}
+    {%- endif %}
+    {%- if server_config.host_file_mounts is defined %}
+    host_file_mounts: {{ server_config.host_file_mounts | tojson }}
+    {%- endif %}
+    {%- if server_config.build_context is defined %}
+    build_context: {{ server_config.build_context }}
+    {%- endif %}
+    {%- if server_config.image is defined %}
+    image: {{ server_config.image }}
+    {%- endif %}
   {%- endfor %}
 
 services:


### PR DESCRIPTION
## Generic MCP sidecar + domain-knowledge skills + tool-use observability

Bundles four related improvements to make the MCP integration both more flexible and more operable. Framework stays tool-agnostic — all enhancements are generic.

### Summary

**1. Generic MCP sidecar support**

Lets any MCP server declare `build_context` or `image` in its config and run as its own Docker container, communicating with the chatbot over HTTP. Previously only external HTTP MCP servers (like deepwiki) and in-process stdio servers were supported. The compose template now emits a sidecar service block for any MCP server that declares a build or image, with optional `env`, `env_from_secrets`, and `host_file_mounts` (literal path or `{src, dest}`) fields. Supports `host_mode` for hosts that need it.

**2. `skill` field for MCP servers**

Each MCP server can now declare `skill: <name>` in the deployment config. Archi loads the corresponding `.md` file from the skills directory and appends it to the agent's **system prompt** (once), not to each tool's description. This avoids multiplying a ~5 KB skill by the number of tools in the catalog (which would add ~40 K prompt tokens for a 33-tool MCP server). Fields `build_context`, `image`, `env_from_secrets`, `host_file_mounts`, `skill`, `path` are stripped before passing configs to `MultiServerMCPClient` so they don't break the client.

**3. MCP tool-input capture for UI visibility**

MCP tool calls were displaying empty `{}` arguments in the chat UI because LLM tool-call chunks arrive without complete args — they only materialize at tool-execution time. The existing `_store_tool_input` + `RunMemory.record_tool_input` mechanism already handles this for static tools (retriever, local_files); this PR wires the same hook into `sync_wrapper` inside `_build_mcp_tools`, so MCP invocations record their real args into RunMemory and the UI can display them.

**4. Cache-hit telemetry**

`_extract_usage_from_message`/`_extract_usage_from_metadata` now also pull cached-token counts from LangChain's standardized `input_token_details.cache_read` and the OpenAI-native `prompt_tokens_details.cached_tokens`. Aggregated across the turn and logged as `Usage: prompt=X (cached=Y, Z% hit) completion=W total=T`. Enables measuring prompt-caching effectiveness as the system prompt / tool catalog evolves. Non-cache-reporting providers see `cached=0` with no errors.

### Changes

| File | Purpose |
|---|---|
| `src/cli/templates/base-config.yaml` | Render `env`, `env_from_secrets`, `host_file_mounts`, `build_context`, `image`, `skill` fields on MCP server configs |
| `src/cli/templates/base-compose.yaml` | Emit a compose service block for any MCP server with `build_context`/`image`; supports per-server env, secrets, host-file mounts, and `host_mode` |
| `src/cli/managers/templates_manager.py` | Pass `mcp_servers` config through to the compose template |
| `src/archi/pipelines/agents/tools/mcp.py` | Load skills, strip archi-only fields before `MultiServerMCPClient`, return skills text separately so it can be added to the system prompt once |
| `src/archi/pipelines/agents/base_react.py` | System-prompt injection of MCP skills; MCP sync_wrapper records tool input into RunMemory; cache-token fields surfaced in usage extraction; per-turn usage logging |

### Backwards compatibility

- Existing MCP server configs (stdio with `command`/`args`, external HTTP with just `url`) continue to work unchanged.
- Deployments with no `skill` field behave exactly as before.
- Non-OpenAI providers report `cached_tokens=0` with no errors.
