### PR TITLE
Fix two A/B streaming crashes that hid the vote buttons

### DIFF
--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -1625,6 +1625,7 @@ class ChatWrapper:
             client_sent_msg_ts,
             client_timeout,
             timestamps,
+            config_name,
             user_id=user_id,
         )
         if error_code is not None:
@@ -1808,17 +1809,18 @@ class ChatWrapper:
                 logger.error("Failed to store user message: %s", exc)
 
         # Store both responses as messages
+        pipeline_used = ChatWrapper._get_agent_class_from_cfg(self.services_config.get("chat_app", {})) or ""
         arm_a_mid = self._store_assistant_message(
             context.conversation_id,
             arm_a_final_text,
             model_used=f"{arm_a_variant.provider or ''}/{arm_a_variant.model or ''}".strip("/"),
-            pipeline_used=self.current_pipeline_used,
+            pipeline_used=pipeline_used,
         )
         arm_b_mid = self._store_assistant_message(
             context.conversation_id,
             arm_b_final_text,
             model_used=f"{arm_b_variant.provider or ''}/{arm_b_variant.model or ''}".strip("/"),
-            pipeline_used=self.current_pipeline_used,
+            pipeline_used=pipeline_used,
         )
 
         # Persist per-arm latency for analysis by reusing the timing table keyed by message_id.
@@ -1839,9 +1841,9 @@ class ChatWrapper:
                     response_a_mid=arm_a_mid,
                     response_b_mid=arm_b_mid,
                     model_a=f"{arm_a_variant.provider or ''}/{arm_a_variant.model or ''}".strip("/"),
-                    pipeline_a=self.current_pipeline_used or "",
+                    pipeline_a=pipeline_used,
                     model_b=f"{arm_b_variant.provider or ''}/{arm_b_variant.model or ''}".strip("/"),
-                    pipeline_b=self.current_pipeline_used or "",
+                    pipeline_b=pipeline_used,
                     is_config_a_first=is_champion_first,
                     variant_a_name=arm_a_variant.name,
                     variant_b_name=arm_b_variant.name,

--- a/tests/unit/test_ab_testing.py
+++ b/tests/unit/test_ab_testing.py
@@ -422,7 +422,7 @@ def test_stream_ab_comparison_emits_per_arm_final_before_ab_meta():
     chat._get_last_user_message_id = Mock(return_value=100)
     chat.conv_service = Mock()
     chat.conv_service.create_ab_comparison.return_value = 42
-    chat.current_pipeline_used = "react"
+    chat.services_config = {"chat_app": {"agent_class": "react"}}
 
     events = list(
         chat.stream_ab_comparison(


### PR DESCRIPTION
`stream_ab_comparison` blew up mid-stream after both arms finished, so the `ab_meta` event never reached the frontend — both responses rendered but no `comparison_id`, no vote buttons, input stuck disabled.

Two bugs:

Missing `config_name` arg to _prepare_chat_context. The other two callers were updated when this arg became required; this one was missed. Added positionally.
Stray `self.current_pipeline_used` — that attribute only exists on `RedmineMailer` / grader app, not `ChatWrapper`. Looks like copy-paste. Replaced with a local derived from the chat config, same way __init__ does it.
After: ab_meta fires with a real comparison_id and vote buttons render.