### PR TITLE
fix(chat_app): agent editor Tools list renders blank (api.py/front-end contract mismatch)

### DIFF
--- a/src/interfaces/chat_app/api.py
+++ b/src/interfaces/chat_app/api.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 from datetime import datetime, timezone
 from functools import wraps
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from flask import Blueprint, jsonify, request, g, current_app, session
 
@@ -41,7 +41,13 @@ def _get_agent_class_name_from_config() -> Optional[str]:
     return chat_cfg.get("agent_class") or chat_cfg.get("pipeline")
 
 
-def _get_agent_tool_registry(agent_class_name: Optional[str]) -> List[str]:
+def _get_agent_tool_registry(agent_class_name: Optional[str]) -> List[Dict[str, str]]:
+    """Return the agent's selectable tools as ``{"name", "description"}`` objects.
+
+    The chat_app front-end (renderAgentToolPalette) reads ``tool.name`` /
+    ``tool.description`` from each entry, so this must return objects — a bare
+    list of name strings renders as blank, unselectable checkboxes.
+    """
     if not agent_class_name:
         return []
     try:
@@ -55,25 +61,32 @@ def _get_agent_tool_registry(agent_class_name: Optional[str]) -> List[str]:
     try:
         dummy = agent_cls.__new__(agent_cls)
         registry = agent_cls.get_tool_registry(dummy) or {}
-        return sorted([name for name in registry.keys() if isinstance(name, str)])
+        descriptions = {}
+        if hasattr(agent_cls, "get_tool_descriptions"):
+            try:
+                descriptions = agent_cls.get_tool_descriptions(dummy) or {}
+            except Exception:
+                descriptions = {}
+        return [
+            {"name": name, "description": descriptions.get(name, "")}
+            for name in sorted(n for n in registry.keys() if isinstance(n, str))
+        ]
     except Exception as exc:
         logger.warning("Failed to read tool registry for %s: %s", agent_class_name, exc)
         return []
 
 
 def _build_agent_template(name: str, tools: List[str]) -> str:
-    tools_block = "\n".join(f"- {tool}" for tool in tools) if tools else "- <tool_name>"
-    tools_comment = "\n".join(f"- {tool}" for tool in tools) if tools else "- (no tools available)"
+    """Build the prefilled agent spec in the front-matter form the front-end
+    parser (parseAgentSpec) understands. ``tools`` is a list of tool names."""
+    tools_block = "\n".join(f"  - {tool}" for tool in tools) if tools else "  - <tool_name>"
     return (
-        f"# {name}\n\n"
-        "## Tools\n"
-        f"{tools_block}\n\n"
-        "## Prompt\n"
+        "---\n"
+        f"name: {name}\n"
+        "tools:\n"
+        f"{tools_block}\n"
+        "---\n\n"
         "Write your system prompt here.\n\n"
-        "<!--\n"
-        "Available tools (registry):\n"
-        f"{tools_comment}\n"
-        "-->\n"
     )
 
 
@@ -834,12 +847,13 @@ def get_agent_spec_template():
     try:
         agent_name = request.args.get("name") or "New Agent"
         agent_class = _get_agent_class_name_from_config()
-        tools = _get_agent_tool_registry(agent_class)
+        tool_items = _get_agent_tool_registry(agent_class)
+        tool_names = [t["name"] for t in tool_items]
         return jsonify({
             "name": agent_name,
             "agent_class": agent_class,
-            "tools": tools,
-            "template": _build_agent_template(agent_name, tools),
+            "tools": tool_items,
+            "template": _build_agent_template(agent_name, tool_names),
         }), 200
     except Exception as exc:
         logger.error(f"Error building agent template: {exc}")

--- a/src/interfaces/chat_app/static/chat.js
+++ b/src/interfaces/chat_app/static/chat.js
@@ -1513,14 +1513,16 @@ const UI = {
     const currentForm = this.collectAgentSpecForm();
     const selectedTools = currentForm.tools || [];
     const items = tools.map((tool) => {
-      const toolName = tool.name || '';
+      // Tolerate both shapes: an object {name, description} or a bare name string.
+      const toolName = typeof tool === 'string' ? tool : (tool.name || '');
+      const toolDesc = typeof tool === 'string' ? '' : (tool.description || '');
       const checked = selectedTools.includes(toolName) ? 'checked' : '';
       return `
       <label class="agent-spec-tool">
         <input type="checkbox" class="agent-spec-tool-checkbox" value="${Utils.escapeHtml(toolName)}" ${checked} />
         <div class="agent-spec-tool-info">
           <div class="agent-spec-tool-name">${Utils.escapeHtml(toolName)}</div>
-          <div class="agent-spec-tool-desc">${Utils.escapeHtml(tool.description || '')}</div>
+          <div class="agent-spec-tool-desc">${Utils.escapeHtml(toolDesc)}</div>
         </div>
       </label>`;
     });


### PR DESCRIPTION
## Summary

The agent editor's **Tools** panel renders as empty, unselectable checkboxes (no labels), so no tools can be added to or removed from an agent through the UI.
<img width="866" height="574" alt="image" src="https://github.com/user-attachments/assets/d95d0c19-a740-49e6-82e6-ac205b53d79a" />


## Cause

`GET /api/agents/template` is registered twice with **divergent contracts**:

- `app.py` (`get_agent_template` → `_build_agent_template_payload`) returns `tools` as `{name, description}` **objects** and a **front-matter** template (`---\nname:\ntools:\n---`).
- `api.py` Blueprint (`get_agent_spec_template`) returns `tools` as a list of **name strings** and a **markdown** template (`# Name / ## Tools`).

The `api.py` Blueprint shadows the route and wins. But the front-end is written for the `app.py` contract:

- `renderAgentToolPalette` reads `tool.name` / `tool.description` — on a string, `tool.name` is `undefined`, so every checkbox renders blank and with an empty `value`.
- `parseAgentSpec` only matches the `---` front-matter form, so the markdown template also fails to parse (name/tools empty, whole body dumped into the prompt) when creating a new agent.

## Fix

- **api.py**: return `tools` as `{name, description}` objects (with registry descriptions) and emit the front-matter template the parser expects — so the `api.py` and `app.py` handlers and the front-end all agree on the payload shape.
- **chat.js**: harden `renderAgentToolPalette` to accept either a tool object or a bare name string (the same tolerance already used elsewhere in the file), so a future contract drift degrades gracefully instead of rendering blanks.

## Testing

Verified live against a running deployment (`CMSCompOpsAgent`): `GET /api/agents/template` now returns tool objects with descriptions and a front-matter template that `parseAgentSpec`'s regex matches; the editor's Tools panel populates with named, selectable, described checkboxes.

Note: the duplicate `app.py` / `api.py` registration of this route is left in place (both now return the same shape); de-duplicating it is a reasonable follow-up.
