### PR TITLE
Eliminating Pre-tool Naration

### DIFF
--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -385,6 +385,11 @@ class BaseReActAgent:
                             metadata={"event_type": "tool_start"},
                             final=False,
                         )
+                        # A tool call ends the current turn: reset the answer
+                        # buffer so pre-tool narration doesn't leak into the
+                        # final answer (it stays in the trace via text events).
+                        accumulated_content = ""
+                        last_visible_content = ""
 
                 # Detect tool result (ToolMessage with tool_call_id)
                 tool_call_id = getattr(message, "tool_call_id", None)
@@ -694,6 +699,11 @@ class BaseReActAgent:
                             metadata={"event_type": "tool_start"},
                             final=False,
                         )
+                        # A tool call ends the current turn: reset the answer
+                        # buffer so pre-tool narration doesn't leak into the
+                        # final answer (it stays in the trace via text events).
+                        accumulated_content = ""
+                        last_visible_content = ""
 
                 # Detect tool result
                 tool_call_id = getattr(message, "tool_call_id", None)

--- a/src/interfaces/chat_app/static/chat.js
+++ b/src/interfaces/chat_app/static/chat.js
@@ -3077,6 +3077,34 @@ const UI = {
     }
   },
 
+  renderNarrationStep(messageId, event) {
+    const timeline = document.querySelector(`.trace-container[data-message-id="${messageId}"] .step-timeline`);
+    if (!timeline) return;
+
+    const stepHtml = `
+      <div class="step thinking-step completed" data-step-id="${Utils.escapeAttr(event.step_id)}">
+        <div class="step-connector">
+          <span class="step-marker completed-marker"></span>
+          <div class="step-line"></div>
+        </div>
+        <div class="step-content">
+          <div class="step-header" onclick="UI.toggleStepExpanded('${Utils.escapeAttr(event.step_id)}')">
+            <span class="step-icon">📝</span>
+            <span class="step-label">Planning</span>
+            <span class="step-timer"></span>
+            <button class="step-toggle" aria-label="Expand planning details">&#9654;</button>
+          </div>
+          <div class="step-details" style="display: none;">
+            <div class="section-label">Details</div>
+            <pre><code>${Utils.escapeHtml(event.content || '')}</code></pre>
+          </div>
+        </div>
+      </div>`;
+
+    timeline.insertAdjacentHTML('beforeend', stepHtml);
+    this.scrollToBottom();
+  },
+
   // =========================================================================
   // Tool Step Rendering (Timeline Style)
   // =========================================================================
@@ -3366,9 +3394,15 @@ const UI = {
     const toolStartEvents = {};
     const thinkingEvents = {};
     let usageData = null;
+    // Text events are cumulative per-turn snapshots; the last one before a
+    // tool call is that turn's narration. Trailing text is the final answer.
+    let pendingNarration = '';
+    let narrationCount = 0;
 
     for (const event of events) {
-      if (event.type === 'thinking_start') {
+      if (event.type === 'text') {
+        pendingNarration = event.content || '';
+      } else if (event.type === 'thinking_start') {
         thinkingEvents[event.step_id] = event;
       } else if (event.type === 'thinking_end') {
         const startEvent = thinkingEvents[event.step_id];
@@ -3376,6 +3410,14 @@ const UI = {
           this.addHistoricalThinkingStep(timeline, event);
         }
       } else if (event.type === 'tool_start' || event.type === 'tool_use') {
+        if (pendingNarration.trim()) {
+          narrationCount += 1;
+          this.addHistoricalNarrationStep(timeline, {
+            step_id: `narration-${narrationCount}`,
+            content: pendingNarration.trim(),
+          });
+          pendingNarration = '';
+        }
         toolStartEvents[event.tool_call_id] = event;
         // Add the tool step immediately
         this.addHistoricalToolStep(timeline, event, null);
@@ -3411,6 +3453,29 @@ const UI = {
           <div class="step-details" style="display: none;">
             <div class="section-label">Details</div>
             <pre><code>${Utils.escapeHtml(event.thinking_content || '')}</code></pre>
+          </div>
+        </div>
+      </div>`;
+    timeline.insertAdjacentHTML('beforeend', stepHtml);
+  },
+
+  addHistoricalNarrationStep(timeline, event) {
+    const stepHtml = `
+      <div class="step thinking-step completed" data-step-id="${Utils.escapeAttr(event.step_id)}">
+        <div class="step-connector">
+          <span class="step-marker completed-marker"></span>
+          <div class="step-line"></div>
+        </div>
+        <div class="step-content">
+          <div class="step-header" onclick="UI.toggleStepExpanded('${Utils.escapeAttr(event.step_id)}')">
+            <span class="step-icon">📝</span>
+            <span class="step-label">Planning</span>
+            <span class="step-timer"></span>
+            <button class="step-toggle" aria-label="Expand planning details">&#9654;</button>
+          </div>
+          <div class="step-details" style="display: none;">
+            <div class="section-label">Details</div>
+            <pre><code>${Utils.escapeHtml(event.content || '')}</code></pre>
           </div>
         </div>
       </div>`;
@@ -4741,6 +4806,9 @@ const Chat = {
       case 'thinking_end':
         UI.renderThinkingEnd(messageId, event);
         break;
+      case 'narration':
+        UI.renderNarrationStep(messageId, event);
+        break;
     }
   },
 
@@ -4793,6 +4861,18 @@ const Chat = {
         resetTimeout();
         // Handle trace events
         if (event.type === 'tool_start') {
+          // Text streamed before a tool call is that turn's narration:
+          // move it into the activity timeline before the tool step lands.
+          if (streamedText.trim()) {
+            const narration = {
+              type: 'narration',
+              step_id: `narration-${this.state.activeTrace.events.length}`,
+              content: streamedText.trim(),
+            };
+            this.state.activeTrace.events.push(narration);
+            this._renderStreamEvent(messageId, narration);
+            streamedText = '';
+          }
           this.state.activeTrace.toolCalls.set(event.tool_call_id, {
             name: event.tool_name,
             args: event.tool_args,


### PR DESCRIPTION
Problem

When a ReAct agent takes multiple tool-calling turns, the streamed final answer
contains every turn's "thinking aloud" text concatenated together, not just the
actual answer. A typical multi-tool response looks like:

> Let me get the full text of the most relevant ticket. There's a conflict
> between two tickets: one from May 2026 (#6068) saying… Let me check ticket
> 2699 for more context… Now I have a much clearer picture… **Yes, the answer
> to your question is…**

Only the last part is the answer; the rest is per-turn narration the model
emitted before each tool call, which should live in the agent trace.

## Root cause

Two things in `BaseReActAgent.stream()` / `astream()` combine to cause this:

1. `accumulated_content` collects AI text chunks across the whole run and is
   never reset at turn boundaries, so it grows into
   `turn 1 narration + turn 2 narration + … + final answer`.
2. The end-of-stream code tries to use "the last AI message with content" as
   the answer, but with `stream_mode="messages"` AI text only arrives as
   chunks, which are excluded from `all_messages` — so that lookup always
   fails and the code falls back to the full accumulated buffer.

`<think>` content is already stripped correctly; this is specifically about
visible narration between tool calls.

Fix

* **`base_react.py`** — when a new tool call is detected (i.e. the model ended
  its turn by choosing a tool), reset `accumulated_content` /
  `last_visible_content`. The final answer is then naturally the last turn's
  text. The model's context is unaffected — LangGraph state still carries the
  full message history — and the narration still reaches the trace via the
  already-emitted `text` events.

* **`chat.js`** — those `text` events were stored in the trace but never
  rendered (the activity panel only had branches for thinking/tool/usage
  events). Add a collapsible "Planning" step, styled like the existing
  Thinking step, for each turn's narration:
  * live path: snapshot the streamed text into a step when a `tool_start`
    event arrives;
  * historical path: render the last `text` event preceding each `tool_start`
    when reloading a conversation.
  Trailing text after the last tool call is the final answer and is never
  turned into a step.