### PR TITLE
Cancellable async generation + Mid-run context management

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -60,6 +60,38 @@ The main chat interface.
 | `num_responses_until_feedback` | int | `3` | Responses before prompting for feedback |
 | `auth.enabled` | bool | `false` | Enable authentication |
 | `alerts.managers` | list | `[]` | Usernames allowed to create and delete alerts |
+| `context_management` | dict | `{}` | Mid-run context management (see below) |
+
+#### `services.chat_app.context_management`
+
+Keeps a single agent run from overflowing the model's context window when
+tool calls return large outputs. Two mechanisms run before each model call:
+clearing older tool outputs once the transcript crosses a token trigger, and
+summarizing older history as a deeper backstop. Both are enabled by default
+when the model's context window is known (default triggers are 60% and 75%
+of the window respectively); when the window cannot be determined, they stay
+off unless `trigger_tokens` is set explicitly.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Master switch for both mechanisms |
+| `clear_tool_uses.enabled` | bool | `true` | Clear older tool outputs past the trigger |
+| `clear_tool_uses.trigger_tokens` | int | 60% of context window | Transcript size that triggers clearing |
+| `clear_tool_uses.keep` | int | `3` | Most recent tool outputs never cleared |
+| `summarization.enabled` | bool | `true` | Summarize older history past the trigger |
+| `summarization.trigger_tokens` | int | 75% of context window | Transcript size that triggers summarization |
+| `summarization.keep_messages` | int | `20` | Most recent messages kept verbatim |
+| `summarization.model` | string | agent's own LLM | `provider/model` used to write summaries (e.g. a small local model) |
+
+```yaml
+services:
+  chat_app:
+    context_management:
+      clear_tool_uses:
+        keep: 3
+      summarization:
+        model: local/qwen3.5:4b
+```
 
 #### `services.chat_app.alerts`
 

--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -4,6 +4,11 @@ import time
 import uuid
 
 from langchain.agents import create_agent
+from langchain.agents.middleware import (
+    ClearToolUsesEdit,
+    ContextEditingMiddleware,
+    SummarizationMiddleware,
+)
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 try:
@@ -31,6 +36,8 @@ class BaseReActAgent:
     process user queries using configurable language models and prompts.
     """
     DEFAULT_RECURSION_LIMIT = 50
+    DEFAULT_CLEAR_TOOL_USES_FRACTION = 0.6
+    DEFAULT_SUMMARIZATION_FRACTION = 0.75
 
     def __init__(
         self,
@@ -1196,8 +1203,109 @@ class BaseReActAgent:
             logger.error(f"Failed to load MCP tools: {e}", exc_info=True)
 
     def _build_static_middleware(self) -> List[Callable]:
-        """Build and returns static middleware defined in the config."""
-        return []
+        """Build mid-run context management middleware.
+
+        Tool outputs accumulate between ReAct steps without passing through
+        the turn-start trimming, so a single run can overflow the model's
+        context window. Two defenses, both configurable via a
+        `context_management` block (pipeline config, falling back to
+        services.chat_app): clearing older tool outputs once the transcript
+        crosses a token trigger, and summarizing older history as a deeper
+        backstop. Default triggers derive from the model's context window;
+        without a known window the middleware stays off unless triggers are
+        set explicitly.
+        """
+        cfg = self._context_management_config()
+        if cfg.get("enabled") is False:
+            return []
+
+        context_window = self._get_model_context_window()
+        middleware: List[Callable] = []
+
+        clear_cfg = cfg.get("clear_tool_uses")
+        clear_cfg = clear_cfg if isinstance(clear_cfg, dict) else {}
+        if clear_cfg.get("enabled", True):
+            trigger = clear_cfg.get("trigger_tokens")
+            if trigger is None and context_window:
+                trigger = int(context_window * self.DEFAULT_CLEAR_TOOL_USES_FRACTION)
+            if trigger:
+                middleware.append(
+                    ContextEditingMiddleware(
+                        edits=[
+                            ClearToolUsesEdit(
+                                trigger=int(trigger),
+                                keep=int(clear_cfg.get("keep", 3)),
+                                placeholder=(
+                                    "[Tool output cleared to free context space. "
+                                    "Re-run the tool with narrower filters if this data is still needed.]"
+                                ),
+                            )
+                        ]
+                    )
+                )
+                logger.info(
+                    "Context editing enabled for %s: old tool outputs cleared beyond %d tokens.",
+                    self.__class__.__name__,
+                    int(trigger),
+                )
+
+        summary_cfg = cfg.get("summarization")
+        summary_cfg = summary_cfg if isinstance(summary_cfg, dict) else {}
+        if summary_cfg.get("enabled", True):
+            trigger = summary_cfg.get("trigger_tokens")
+            if trigger is None and context_window:
+                trigger = int(context_window * self.DEFAULT_SUMMARIZATION_FRACTION)
+            if trigger:
+                model = self._resolve_summarization_model(summary_cfg.get("model"))
+                if model is not None:
+                    middleware.append(
+                        SummarizationMiddleware(
+                            model=model,
+                            max_tokens_before_summary=int(trigger),
+                            messages_to_keep=int(summary_cfg.get("keep_messages", 20)),
+                        )
+                    )
+                    logger.info(
+                        "History summarization enabled for %s beyond %d tokens.",
+                        self.__class__.__name__,
+                        int(trigger),
+                    )
+
+        return middleware
+
+    def _context_management_config(self) -> Dict[str, Any]:
+        """Read the context_management block, pipeline config first then chat_app."""
+        value = None
+        if isinstance(self.pipeline_config, dict):
+            value = self.pipeline_config.get("context_management")
+        if value is None and isinstance(self.config, dict):
+            services_cfg = self.config.get("services", {})
+            if isinstance(services_cfg, dict):
+                chat_cfg = services_cfg.get("chat_app", {})
+                if isinstance(chat_cfg, dict):
+                    value = chat_cfg.get("context_management")
+        return value if isinstance(value, dict) else {}
+
+    def _resolve_summarization_model(self, model_ref: Optional[str]) -> Optional[Any]:
+        """Resolve the summarization model; defaults to the agent's own LLM."""
+        if not model_ref:
+            return self.agent_llm
+        try:
+            provider, model_id = self._parse_provider_model(model_ref)
+            providers_config = {}
+            if isinstance(self.config, dict):
+                services_cfg = self.config.get("services", {}) if isinstance(self.config.get("services", {}), dict) else {}
+                chat_cfg = services_cfg.get("chat_app", {}) if isinstance(services_cfg, dict) else {}
+                providers_config = chat_cfg.get("providers", {}) if isinstance(chat_cfg, dict) else {}
+            provider_config = self._build_provider_config(provider, providers_config)
+            return get_model(provider, model_id, provider_config)
+        except Exception as exc:
+            logger.warning(
+                "Could not initialise summarization model '%s' (%s); falling back to the agent LLM.",
+                model_ref,
+                exc,
+            )
+            return self.agent_llm
 
     def _store_documents(self, stage: str, docs: Sequence[Document]) -> None:
         """Centralised helper used by tools to record documents into the active memory."""

--- a/src/archi/pipelines/agents/utils/async_bridge.py
+++ b/src/archi/pipelines/agents/utils/async_bridge.py
@@ -1,0 +1,95 @@
+import asyncio
+import queue
+import threading
+from typing import Any, AsyncIterator, Iterator, Optional
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_DONE = object()
+
+
+class StreamCancelled(Exception):
+    """Raised in the consuming thread when the underlying task was cancelled."""
+
+
+class AsyncStreamBridge:
+    """Run an async generator as a cancellable task on a background loop and
+    consume its items from a synchronous iterator.
+
+    The chat app serves requests from worker threads, where a model call blocks
+    the thread inside a socket read and cannot be interrupted. Running the
+    pipeline's astream() as an asyncio task changes that: cancel() raises
+    CancelledError at the task's current await point, which unwinds through
+    httpx and closes the HTTP connection — the signal Ollama (and any other
+    provider) accepts to abort an in-flight generation, including mid-prefill.
+
+    Items are pumped into an unbounded thread-safe queue (SSE events are small
+    and consumed promptly, and a bounded put would block the shared event
+    loop). cancel() is thread-safe and idempotent.
+    """
+
+    def __init__(self, agen: AsyncIterator[Any], loop: asyncio.AbstractEventLoop):
+        self._agen = agen
+        self._loop = loop
+        self._queue: queue.Queue = queue.Queue()
+        self._task: Optional[asyncio.Task] = None
+        self._cancel_requested = threading.Event()
+        self._started = threading.Event()
+        loop.call_soon_threadsafe(self._start)
+
+    def _start(self) -> None:
+        self._task = self._loop.create_task(self._pump())
+        self._started.set()
+        if self._cancel_requested.is_set():
+            self._task.cancel()
+
+    async def _pump(self) -> None:
+        try:
+            async for item in self._agen:
+                self._queue.put(item)
+        except asyncio.CancelledError:
+            self._queue.put(StreamCancelled("stream task cancelled"))
+            raise
+        except BaseException as exc:  # surfaced to the consuming thread
+            self._queue.put(exc)
+        else:
+            self._queue.put(_DONE)
+        finally:
+            await _aclose_quietly(self._agen)
+
+    def __iter__(self) -> Iterator[Any]:
+        while True:
+            try:
+                item = self._queue.get(timeout=1.0)
+            except queue.Empty:
+                # Normally a terminal marker arrives; this guards against the
+                # task dying without one (e.g. the loop shut down under it).
+                if self._started.is_set() and self._task is not None and self._task.done() and self._queue.empty():
+                    logger.warning("Async stream task ended without terminal marker.")
+                    return
+                continue
+            if item is _DONE:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+    def cancel(self) -> None:
+        """Cancel the underlying task from any thread; safe to call repeatedly."""
+        if self._cancel_requested.is_set():
+            return
+        self._cancel_requested.set()
+        if self._started.is_set() and self._task is not None:
+            self._loop.call_soon_threadsafe(self._task.cancel)
+
+
+async def _aclose_quietly(agen: Any) -> None:
+    aclose = getattr(agen, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:
+        pass

--- a/src/cli/managers/templates_manager.py
+++ b/src/cli/managers/templates_manager.py
@@ -935,6 +935,16 @@ class TemplateManager:
         mcp_servers = context.config_manager.config.get("mcp_servers", {}) or {}
         template_vars["mcp_servers"] = mcp_servers
 
+        # Sidecar servers (build_context/image) mount their own host_file_mounts;
+        # collect the stdio ones here so the chatbot's host_file_mounts loop emits them.
+        host_file_mounts = []
+        for srv_cfg in mcp_servers.values():
+            if srv_cfg.get("transport") == "stdio" and srv_cfg.get("path"):
+                for m in srv_cfg.get("host_file_mounts", []) or []:
+                    if isinstance(m, str):
+                        host_file_mounts.append(m)
+        template_vars["host_file_mounts"] = host_file_mounts
+
         compose_template = self.env.get_template(BASE_COMPOSE_TEMPLATE)
         compose_rendered = compose_template.render(**template_vars)
 

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -111,6 +111,7 @@ services:
     agent_class: {{ services.chat_app.agent_class | default("CMSCompOpsAgent", true) }}
     agents_dir: "{{ services.chat_app.agents_dir | default('', true) }}"
     recursion_limit: {{ services.chat_app.recursion_limit | default(50, true) }}
+    context_management: {{ services.chat_app.context_management | default({}, true) | tojson }}
     client_timeout_seconds: {{ services.chat_app.client_timeout_seconds | default(600, true) }}
     default_provider: {{ services.chat_app.default_provider | default("local", true) }}
     default_model: {{ services.chat_app.default_model | default("llama3.2", true) }}

--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -31,6 +31,8 @@ from pygments.lexers import (BashLexer, CLexer, CppLexer, FortranLexer,
                              TypeScriptLexer)
 
 from src.archi.archi import archi
+from src.archi.pipelines.agents.utils.async_bridge import AsyncStreamBridge, StreamCancelled
+from src.archi.pipelines.agents.utils.mcp_utils import AsyncLoopThread
 from src.archi.pipelines.agents.agent_spec import (
     AgentSpec,
     AgentSpecError,
@@ -363,6 +365,10 @@ class ChatWrapper:
         # Threading lock for database operations
         self.lock = Lock()
         self._agent_refresh_lock = Lock()
+        # Active per-conversation stream bridges, so /api/cancel_stream can
+        # cancel the underlying asyncio task (which aborts the LLM request).
+        self._stream_bridges: Dict[int, AsyncStreamBridge] = {}
+        self._stream_bridges_lock = Lock()
         
         # load configs
         self.config = get_full_config()
@@ -1107,6 +1113,35 @@ class ChatWrapper:
         finally:
             cursor.close()
             conn.close()
+
+    def _register_stream_bridge(self, conversation_id: int, bridge: AsyncStreamBridge) -> None:
+        with self._stream_bridges_lock:
+            self._stream_bridges[int(conversation_id)] = bridge
+
+    def _unregister_stream_bridge(self, conversation_id: int, bridge: AsyncStreamBridge) -> None:
+        with self._stream_bridges_lock:
+            if self._stream_bridges.get(int(conversation_id)) is bridge:
+                del self._stream_bridges[int(conversation_id)]
+
+    def cancel_active_stream(self, conversation_id) -> bool:
+        """Cancel the running pipeline task for a conversation.
+
+        Cancelling the asyncio task aborts whatever it is awaiting — including
+        an in-flight LLM HTTP request, which closes the connection and makes
+        the provider (e.g. Ollama) stop generating instead of running to
+        completion for nobody. Returns True if an active stream was found.
+        """
+        try:
+            key = int(conversation_id)
+        except (TypeError, ValueError):
+            return False
+        with self._stream_bridges_lock:
+            bridge = self._stream_bridges.get(key)
+        if bridge is None:
+            return False
+        bridge.cancel()
+        logger.info(f"Cancelled pipeline task for conversation {key}")
+        return True
 
 
     def query_conversation_history(self, conversation_id, client_id, user_id: Optional[str] = None):
@@ -2408,6 +2443,7 @@ class ChatWrapper:
         trace_id = None
         trace_events: List[Dict[str, Any]] = []
         stream_start_time = time.time()
+        stream_bridge = None
 
         try:
             context, error_code = self._prepare_chat_context(
@@ -2461,7 +2497,21 @@ class ChatWrapper:
                 pipeline_name=self.archi.pipeline_name if hasattr(self.archi, 'pipeline_name') else None,
             )
 
-            for output in self.archi.stream(history=context.history, conversation_id=context.conversation_id,model=context.model_used):
+            # Run the pipeline as an asyncio task when it supports astream: the
+            # task is cancellable from any thread (see cancel_active_stream),
+            # which aborts an in-flight LLM request instead of letting it run
+            # to completion on the provider after the user hits stop.
+            if self.archi.supports_astream():
+                stream_bridge = AsyncStreamBridge(
+                    self.archi.astream(history=context.history, conversation_id=context.conversation_id, model=context.model_used),
+                    AsyncLoopThread.get_instance().loop,
+                )
+                self._register_stream_bridge(context.conversation_id, stream_bridge)
+                stream_iter = stream_bridge
+            else:
+                stream_iter = self.archi.stream(history=context.history, conversation_id=context.conversation_id, model=context.model_used)
+
+            for output in stream_iter:
                 if client_timeout and time.time() - stream_start_time > client_timeout:
                     if trace_id:
                         total_duration_ms = int((time.time() - stream_start_time) * 1000)
@@ -2630,7 +2680,10 @@ class ChatWrapper:
             }
 
         except GeneratorExit:
-            # User cancelled the stream
+            # Client went away mid-stream; cancel the pipeline task so the
+            # in-flight LLM request is aborted rather than left running.
+            if stream_bridge is not None:
+                stream_bridge.cancel()
             if trace_id:
                 total_duration_ms = int((time.time() - stream_start_time) * 1000)
                 self.update_agent_trace(
@@ -2643,6 +2696,22 @@ class ChatWrapper:
                     cancellation_reason='Stream cancelled by client',
                 )
             raise
+        except StreamCancelled:
+            # Cancelled via /api/cancel_stream, which already stamped the trace.
+            logger.info("Stream for conversation %s cancelled; pipeline task aborted.",
+                        context.conversation_id if context else "?")
+            if trace_id:
+                total_duration_ms = int((time.time() - stream_start_time) * 1000)
+                self.update_agent_trace(
+                    trace_id=trace_id,
+                    events=trace_events,
+                    status='cancelled',
+                    total_tool_calls=formatter.tool_call_count,
+                    total_duration_ms=total_duration_ms,
+                    cancelled_by='user',
+                    cancellation_reason='Cancelled by user request',
+                )
+            return
         except ConversationAccessError as exc:
             logger.warning("Unauthorized conversation access attempt: %s", exc)
             if trace_id:
@@ -2666,6 +2735,8 @@ class ChatWrapper:
                 )
             yield {"type": "error", "status": 500, "message": "server error; see chat logs for message"}
         finally:
+            if context is not None and stream_bridge is not None:
+                self._unregister_stream_bridge(context.conversation_id, stream_bridge)
             if self.cursor is not None:
                 self.cursor.close()
             if self.conn is not None:
@@ -5957,6 +6028,10 @@ class FlaskAppWrapper(object):
                 cancelled_by='user',
                 cancellation_reason='Cancelled by user request',
             )
+
+            # Abort the running pipeline task (and its in-flight LLM request)
+            # rather than just marking the trace cancelled.
+            self.chat.cancel_active_stream(conversation_id)
 
             return jsonify({
                 'success': True,


### PR DESCRIPTION
I ran into 2 issues:
1. Now with my live-state tools, I was receiving way too many tokens worth of context which would cause the model to run for far too long and be less precise. 
2. If I cancelled a heavy prompt and submitted a new prompt, there was nothing stopping Ollama from continuing to generate the old heavy prompt. Thus, an easy second prompt like hello would seem to run for 10min or however long it takes for the first prompt to finish.

Thus, 

## 1. Mid-run context management middleware

Tool outputs accumulate between ReAct steps and bypass the turn-start
trimming, so one run can exceed the context window. `_build_static_middleware()`
now assembles up to two configurable defenses via a `context_management` block
(pipeline config, falling back to `services.chat_app`):

- **Clear tool uses** — replace older tool outputs with a placeholder once the
  transcript crosses a trigger (default 60% of the context window), keeping the
  N most recent (default 3).
- **Summarization** — summarize older history past a deeper trigger (default
  75%), keeping the most recent messages verbatim (default 20). Can use a
  separate, cheaper `provider/model` for the summary; defaults to the agent LLM.

Both default on when the context window is known and off otherwise (unless
triggers are set explicitly); `enabled: false` disables them. Documented in
`docs/configuration.md`, and the block is threaded through `base-config.yaml`
into the seeded runtime config.

## 2. Async streaming bridge with cancellable generation

Chat requests run on worker threads where a model call blocks inside a socket
read and can't be interrupted. New `AsyncStreamBridge` runs the pipeline's
`astream()` as a cancellable asyncio task on the shared background loop and
exposes it as a synchronous iterator. Cancelling raises `CancelledError` at the
task's await point, which closes the LLM HTTP connection — the signal Ollama
(and other providers) accept to abort generation, including mid-prefill.

`ChatWrapper` tracks a bridge per conversation; `cancel_active_stream()` (called
by `/api/cancel_stream` and on client disconnect / `GeneratorExit`) aborts the
running task. Pipelines without `astream` fall back to the existing synchronous
path unchanged.