### PR TITLE
Fix: Gate playbook service initialization

### DIFF
--- a/src/archi/pipelines/agents/playbook_mixin.py
+++ b/src/archi/pipelines/agents/playbook_mixin.py
@@ -61,7 +61,12 @@ class SupportsPlaybooks:
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._playbook_service = self._init_playbook_service()
+        playbooks_requested = bool(
+            set(self._playbook_tool_definitions()).intersection(self.selected_tool_names)
+        )
+        self._playbook_service = (
+            self._init_playbook_service() if playbooks_requested else None
+        )
 
     def _init_playbook_service(self):
         try:
@@ -83,15 +88,18 @@ class SupportsPlaybooks:
         # so this mixin stays usable above a bare base agent (base stays untouched).
         _base = getattr(super(), "_tool_definitions", None)
         defs = _base() if callable(_base) else {}
-        defs.update({
+        defs.update(self._playbook_tool_definitions())
+        return defs
+
+    def _playbook_tool_definitions(self) -> Dict[str, Dict[str, Any]]:
+        return {
             "save_playbook": {"builder": self._build_save_playbook_tool,
                 "description": "Save a new playbook to the user's personal playbook library."},
             "update_playbook": {"builder": self._build_update_playbook_tool,
                 "description": "Modify an existing saved playbook — rename, change its description, or change its body (append or overwrite). Use save_playbook only for brand-new playbooks."},
             "delete_playbook": {"builder": self._build_delete_playbook_tool,
                 "description": "Permanently delete a saved playbook by name (only after the user confirms)."},
-        })
-        return defs
+        }
 
     def _build_save_playbook_tool(self) -> Callable:
         return create_save_playbook_tool(getattr(self, "_playbook_service", None), get_playbook_owner)

--- a/tests/unit/test_playbook_tools.py
+++ b/tests/unit/test_playbook_tools.py
@@ -1,6 +1,6 @@
 import threading
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.utils.playbook_service import (
     Playbook, PlaybookNotFoundError, PlaybookConflictError, PlaybookValidationError,
@@ -418,6 +418,38 @@ def _mixin_agent():
     class _PB(SupportsPlaybooks, BaseReActAgent):
         pass
     return _PB.__new__(_PB)
+
+
+def test_mixin_initializes_service_only_for_selected_playbook_tools():
+    from src.archi.pipelines.agents.playbook_mixin import SupportsPlaybooks
+
+    class _Base:
+        def __init__(self, selected_tool_names):
+            self.selected_tool_names = selected_tool_names
+
+        def _build_static_tools(self):
+            return []
+
+        def _build_static_middleware(self):
+            return []
+
+    class _PB(SupportsPlaybooks, _Base):
+        pass
+
+    with patch.object(_PB, "_init_playbook_service") as initializer:
+        agent = _PB(["mcp"])
+
+    initializer.assert_not_called()
+    assert agent._playbook_service is None
+
+    service = MagicMock()
+    with patch.object(
+        _PB, "_init_playbook_service", return_value=service
+    ) as initializer:
+        agent = _PB(["save_playbook"])
+
+    initializer.assert_called_once_with()
+    assert agent._playbook_service is service
 
 
 def test_base_agent_has_no_playbook_tools():


### PR DESCRIPTION
## Why this change is needed

`CMSCompOpsAgent` includes the `SupportsPlaybooks` mixin. The mixin previously
initialized `PlaybookService` whenever the pipeline was constructed, regardless
of which tools the agent spec selected.

That is harmless inside the chat service, which starts and owns Postgres before
building the agent. It is incorrect for direct pipeline consumers such as QA
evaluation: evaluation supplies an agent configuration directly and can run
without the chat service or Postgres. Constructing the pipeline therefore caused
an unnecessary Postgres connection attempt even when the evaluated agent did not
select any playbook tools.

## Main changes

- Initialize `PlaybookService` only when the agent spec selects one of the
  playbook tools contributed by `SupportsPlaybooks`.
- Derive the selection check from the mixin's existing tool-definition mapping,
  so registration and initialization cannot drift into separate hardcoded lists.
- Keep the existing `Playbook`, `save_playbook`, `update_playbook`, and
  `delete_playbook` behavior unchanged when playbooks are requested.
- Add a lifecycle regression test proving that a non-playbook selection such as
  `mcp` does not initialize the service, while selecting `save_playbook` does.

This deliberately does not rename tools, change agent specifications, alter
trace handling, or modify unrelated documentation and services.

## Resulting behavior

- QA evaluation and other direct pipeline users no longer acquire a Postgres
  dependency merely by constructing `CMSCompOpsAgent`.
- Chat deployments whose agent spec selects playbook tools continue to
  initialize and use `PlaybookService` normally.

## Verification

- Playbook-focused unit tests: 145 passed.
- Complete unit suite: 536 passed.
