### PR TITLE
Parallel tool calls + .mcp.json

### DIFF
--- a/docs/docs/agents_tools.md
+++ b/docs/docs/agents_tools.md
@@ -199,39 +199,16 @@ Archi supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ### How It Works
 
-1. MCP servers are defined in your deployment runtime configuration
+1. MCP servers are declared in a `.mcp.json` file next to your deployment config
 2. An agent spec includes `mcp` in its `tools` list to opt in
 3. At agent initialization, Archi connects to the MCP servers and discovers available tools
 4. The MCP tools are added to the agent's toolset alongside built-in tools
 
 ### Configuration
 
-Define MCP servers in your deployment configuration:
-
-```yaml
-mcp_servers:
-  my_server:
-    transport: "stdio"
-    command: "uvx"
-    args:
-      - "mcp-server-example"
-  web_search:
-    transport: "sse"
-    url: "http://localhost:8080/sse"
-```
-
-Each server entry follows the format expected by the `langchain-mcp-adapters` library:
-
-- **`transport`**: Communication method — `"stdio"` (subprocess), `"streamable_http"` (HTTP), or `"sse"` (HTTP Server-Sent Events)
-- **`command`** / **`args`**: For `stdio` transport, the command to launch the server
-- **`url`** / **`headers`**: For HTTP-based transports, the server endpoint and optional request headers
-
-### `.mcp.json` (Claude-compatible)
-
-Instead of (or in addition to) the YAML block, servers can be declared in a
-`.mcp.json` file placed **next to the deployment config** — the same
-project-scoped file format used by Claude Code and other MCP clients, so one
-file can serve both:
+Declare MCP servers in a `.mcp.json` file placed **next to the deployment
+config** — the same project-scoped file format used by Claude Code and other
+MCP clients, so one file can serve both:
 
 ```json
 {
@@ -260,18 +237,25 @@ Details:
   `stdio`, `"http"` → `streamable_http`, `"sse"` → `sse`. When `type` is
   omitted it is inferred: entries with `command` are stdio, entries with `url`
   are HTTP. Archi-only fields (`path`, `host_file_mounts`, `env_from_secrets`,
-  `build_context`, `image`, `skill`) are allowed in entries and behave exactly
-  as in the YAML block; MCP clients like Claude Code ignore fields they don't
-  know, so the file stays shareable.
-- **Precedence**: if a server name appears in both `.mcp.json` and the YAML
-  `mcp_servers:` block, the YAML definition wins (a warning is logged).
+  `build_context`, `image`, `skill`) are allowed in entries and are ignored by
+  MCP clients like Claude Code that don't know them, so the file stays
+  shareable.
 - **Environment variable expansion**: string values may reference `${VAR}` or
   `${VAR:-default}` (Claude Code's syntax). Expansion happens **at connect
   time inside the service container**, against the container's environment —
   so secrets like the bearer token above come from the deployment's env/secret
   wiring and are never baked into rendered config files. A reference to an
   unset variable with no default disables that server with a clear error in
-  the logs. (Expansion applies to YAML-defined servers too.)
+  the logs.
+
+Each server entry follows the format expected by the `langchain-mcp-adapters`
+library once normalized:
+
+- **`transport`** (from `type`): `stdio` (subprocess), `streamable_http`
+  (HTTP), or `sse` (HTTP Server-Sent Events)
+- **`command`** / **`args`**: for `stdio`, the command to launch the server
+- **`url`** / **`headers`**: for HTTP-based transports, the endpoint and
+  optional request headers
 
 ### Agent Spec Example
 

--- a/docs/docs/agents_tools.md
+++ b/docs/docs/agents_tools.md
@@ -222,9 +222,56 @@ mcp_servers:
 
 Each server entry follows the format expected by the `langchain-mcp-adapters` library:
 
-- **`transport`**: Communication method — `"stdio"` (subprocess) or `"sse"` (HTTP Server-Sent Events)
+- **`transport`**: Communication method — `"stdio"` (subprocess), `"streamable_http"` (HTTP), or `"sse"` (HTTP Server-Sent Events)
 - **`command`** / **`args`**: For `stdio` transport, the command to launch the server
-- **`url`**: For `sse` transport, the server endpoint
+- **`url`** / **`headers`**: For HTTP-based transports, the server endpoint and optional request headers
+
+### `.mcp.json` (Claude-compatible)
+
+Instead of (or in addition to) the YAML block, servers can be declared in a
+`.mcp.json` file placed **next to the deployment config** — the same
+project-scoped file format used by Claude Code and other MCP clients, so one
+file can serve both:
+
+```json
+{
+  "mcpServers": {
+    "local-tools": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mcp-server-example"]
+    },
+    "remote-api": {
+      "type": "http",
+      "url": "https://example.org/mcp",
+      "headers": {"Authorization": "Bearer ${MCP_API_TOKEN}"}
+    }
+  }
+}
+```
+
+Details:
+
+- **Discovery**: `archi create` looks for `.mcp.json` in the same directory as
+  each `--config` file. To use a different file, set `mcp_servers_file:
+  path/to/servers.json` in the YAML config (relative paths resolve against the
+  config file).
+- **Field mapping**: Claude's `type` values map onto transports — `"stdio"` →
+  `stdio`, `"http"` → `streamable_http`, `"sse"` → `sse`. When `type` is
+  omitted it is inferred: entries with `command` are stdio, entries with `url`
+  are HTTP. Archi-only fields (`path`, `host_file_mounts`, `env_from_secrets`,
+  `build_context`, `image`, `skill`) are allowed in entries and behave exactly
+  as in the YAML block; MCP clients like Claude Code ignore fields they don't
+  know, so the file stays shareable.
+- **Precedence**: if a server name appears in both `.mcp.json` and the YAML
+  `mcp_servers:` block, the YAML definition wins (a warning is logged).
+- **Environment variable expansion**: string values may reference `${VAR}` or
+  `${VAR:-default}` (Claude Code's syntax). Expansion happens **at connect
+  time inside the service container**, against the container's environment —
+  so secrets like the bearer token above come from the deployment's env/secret
+  wiring and are never baked into rendered config files. A reference to an
+  unset variable with no default disables that server with a clear error in
+  the logs. (Expansion applies to YAML-defined servers too.)
 
 ### Agent Spec Example
 

--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Iterator, AsyncIterator, Set, Tuple
+import asyncio
 import re
 import threading
 import time
@@ -60,7 +61,11 @@ class BaseReActAgent:
         # single background loop, so concurrent calls (when the model emits
         # parallel tool calls) corrupt response routing and leak server-side
         # connections. Holding this lock makes parallel calls run one at a time.
+        # The threading lock covers the sync path (stream); the asyncio lock
+        # covers the coroutine path (astream), where tools run as concurrent
+        # coroutines on the session's own loop instead of blocking threads.
         self._mcp_call_lock = threading.Lock()
+        self._mcp_async_lock = asyncio.Lock()
         self._mcp_skills_text: str = ""
         self._active_tools: List[Callable] = []
         self._static_middleware: Optional[List[Callable]] = None
@@ -1165,15 +1170,18 @@ class BaseReActAgent:
                 - Runs on the SAME loop where the client was initialized
                 - Session streams remain valid
                 """
-                # Capture the runner + the shared MCP call lock in closure
+                # Capture the runner + the shared MCP call locks in closure
                 runner = self._async_runner
                 mcp_call_lock = self._mcp_call_lock
+                mcp_async_lock = self._mcp_async_lock
                 tool_name = async_tool.name
 
-                def sync_wrapper(*args, **kwargs):
-                    if runner.in_loop_thread():
-                        raise RuntimeError("sync_wrapper called from MCP loop thread; would deadlock")
-                    # Streamed tool_call chunks arrive without args; record here so the UI can resolve them by tool_call_id.
+                orig_coroutine = async_tool.coroutine
+
+                async def locked_coroutine(*args, _orig=orig_coroutine, **kwargs):
+                    # astream invokes the tool coroutine directly on the MCP
+                    # session loop; serialize through the asyncio lock so
+                    # parallel tool calls can't corrupt the shared session.
                     try:
                         recorded = {
                             k: v
@@ -1186,9 +1194,18 @@ class BaseReActAgent:
                         logger.debug(
                             "Failed to record MCP tool input for %s: %s", tool_name, exc
                         )
+                    async with mcp_async_lock:
+                        return await _orig(*args, **kwargs)
+
+                async_tool.coroutine = locked_coroutine
+
+                def sync_wrapper(*args, **kwargs):
+                    if runner.in_loop_thread():
+                        raise RuntimeError("sync_wrapper called from MCP loop thread; would deadlock")
                     # Run on the background loop - NOT a new loop! Serialize via
                     # the shared lock so parallel tool calls can't hit the single
                     # MCP session concurrently (which deadlocks + leaks connections).
+                    # Input recording happens inside locked_coroutine for both paths.
                     with mcp_call_lock:
                         return runner.run(async_tool.coroutine(*args, **kwargs))
 

--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Iterator, AsyncIterator, Set, Tuple
 import re
+import threading
 import time
 import uuid
 
@@ -55,6 +56,11 @@ class BaseReActAgent:
         self._active_memory: Optional[RunMemory] = None
         self._static_tools: Optional[List[Callable]] = None
         self._mcp_tools: Optional[List[Callable]] = None
+        # Serializes MCP tool calls: all MCP tools share one client/session on a
+        # single background loop, so concurrent calls (when the model emits
+        # parallel tool calls) corrupt response routing and leak server-side
+        # connections. Holding this lock makes parallel calls run one at a time.
+        self._mcp_call_lock = threading.Lock()
         self._mcp_skills_text: str = ""
         self._active_tools: List[Callable] = []
         self._static_middleware: Optional[List[Callable]] = None
@@ -1159,8 +1165,9 @@ class BaseReActAgent:
                 - Runs on the SAME loop where the client was initialized
                 - Session streams remain valid
                 """
-                # Capture the runner in closure
+                # Capture the runner + the shared MCP call lock in closure
                 runner = self._async_runner
+                mcp_call_lock = self._mcp_call_lock
                 tool_name = async_tool.name
 
                 def sync_wrapper(*args, **kwargs):
@@ -1179,8 +1186,11 @@ class BaseReActAgent:
                         logger.debug(
                             "Failed to record MCP tool input for %s: %s", tool_name, exc
                         )
-                    # Run on the background loop - NOT a new loop!
-                    return runner.run(async_tool.coroutine(*args, **kwargs))
+                    # Run on the background loop - NOT a new loop! Serialize via
+                    # the shared lock so parallel tool calls can't hit the single
+                    # MCP session concurrently (which deadlocks + leaks connections).
+                    with mcp_call_lock:
+                        return runner.run(async_tool.coroutine(*args, **kwargs))
 
                 # Assign the wrapper to the tool's 'func' attribute
                 async_tool.func = sync_wrapper

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -120,7 +120,7 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
         else:
             # For HTTP-based transports, `env` is for the sidecar container (compose),
             # not the MCP client connection — drop it here.
-            if server_cfg.get("env").get("httpx_client_factory"):
+            if (server_cfg.get("env") or {}).get("httpx_client_factory"):
                 cfg["httpx_client_factory"] = lambda **kwargs: mcp_http_client_factory(verify=server_cfg.get("host_file_mounts")[0],**kwargs)
             cfg.pop("env", None)
         client_configs[name] = cfg

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -12,6 +12,37 @@ from src.archi.pipelines.agents.utils.skill_utils import load_skill
 
 logger = get_logger(__name__)
 
+
+def _patch_langchain_mcp_dict_schema_recursion() -> None:
+    """Work around a langchain-core / langchain-mcp-adapters incompatibility.
+
+    langchain-mcp-adapters sets each tool's ``args_schema`` to the MCP server's raw
+    JSON-schema *dict* rather than a pydantic model. langchain-core's
+    ``_filter_injected_args`` then calls ``get_all_basemodel_annotations(args_schema)``;
+    for a non-pydantic input that helper recurses on ``get_origin(cls)``, which for a dict
+    (then ``None``) never terminates -> ``RecursionError`` on every MCP tool call. It is
+    caught and logged at DEBUG, so it is non-fatal, but it burns ~1000 stack frames per
+    call and floods the logs. We add the missing base case: a non-type with no generic
+    origin yields no annotations instead of recursing. Real pydantic ``args_schema`` models
+    are unaffected. Idempotent; safe to call on every init.
+    """
+    from typing import get_origin
+    from langchain_core.tools import base as _lc_tools_base
+
+    if getattr(_lc_tools_base, "_archi_dict_schema_guard", False):
+        return
+    _orig = _lc_tools_base.get_all_basemodel_annotations
+
+    def _guarded(cls, *args, **kwargs):
+        if not isinstance(cls, type) and get_origin(cls) is None:
+            return {}
+        return _orig(cls, *args, **kwargs)
+
+    _lc_tools_base.get_all_basemodel_annotations = _guarded
+    _lc_tools_base._archi_dict_schema_guard = True
+    logger.info("Applied langchain-core args_schema recursion guard for MCP dict schemas.")
+
+
 async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[BaseTool], str]:
     """
     Initializes the MCP client and fetches tool definitions.
@@ -24,6 +55,8 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
             here only once per agent rather than into each tool description, so
             the content doesn't multiply by tool count.
     """
+
+    _patch_langchain_mcp_dict_schema_recursion()
 
     mcp_servers = get_mcp_servers_config()
 

--- a/src/archi/pipelines/agents/tools/mcp.py
+++ b/src/archi/pipelines/agents/tools/mcp.py
@@ -8,6 +8,7 @@ from langchain.tools import BaseTool
 
 from src.utils.config_access import get_mcp_servers_config, get_full_config
 from src.utils.logging import get_logger
+from src.utils.mcp_json import expand_env_placeholders
 from src.archi.pipelines.agents.utils.skill_utils import load_skill
 
 logger = get_logger(__name__)
@@ -70,6 +71,7 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     }
     client_configs: dict[str, dict] = {}
     server_skills: dict[str, str] = {}
+    failed_servers: dict[str, str] = {}
     full_config = get_full_config()
     for name, server_cfg in mcp_servers.items():
         # Load any declared skill so we can append it to this server's tool descriptions.
@@ -80,6 +82,17 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
                 server_skills[name] = skill_content
 
         cfg = {k: v for k, v in server_cfg.items() if k not in _archi_only_fields}
+        # Expand ${VAR} / ${VAR:-default} placeholders (the Claude .mcp.json syntax)
+        # against this process's env at connect time — so secrets referenced from
+        # url/headers/env come from the container environment instead of being
+        # baked into rendered configs. Must run BEFORE the stdio os.environ merge
+        # below: only declared values get expanded, never the inherited host env.
+        try:
+            cfg = expand_env_placeholders(cfg, os.environ)
+        except ValueError as e:
+            logger.error(f"Skipping MCP server '{name}': {e}")
+            failed_servers[name] = str(e)
+            continue
         transport = cfg.get("transport")
         if transport == "stdio":
             # stdio subprocesses inherit nothing by default (mcp.client.stdio uses
@@ -96,7 +109,6 @@ async def initialize_mcp_client() -> Tuple[Optional[MultiServerMCPClient], List[
     client = MultiServerMCPClient(client_configs)
 
     all_tools: List[BaseTool] = []
-    failed_servers: dict[str, str] = {}
 
     for name in client_configs.keys():
         try:

--- a/src/cli/managers/config_manager.py
+++ b/src/cli/managers/config_manager.py
@@ -56,19 +56,27 @@ class ConfigurationManager:
         # Track origin for relative-path resolution (e.g., prompts).
         config["_config_path"] = str(config_filepath)
 
-        self._merge_mcp_json(config, config_filepath)
+        self._load_mcp_servers(config, config_filepath)
 
         return config
 
     @staticmethod
-    def _merge_mcp_json(config: Dict[str, Any], config_filepath: Path) -> None:
-        """Merge MCP servers from a Claude-style .mcp.json into config['mcp_servers'].
+    def _load_mcp_servers(config: Dict[str, Any], config_filepath: Path) -> None:
+        """Populate config['mcp_servers'] from a Claude-style .mcp.json.
 
-        The file is the one named by the config's optional `mcp_servers_file` key
-        (resolved relative to the config file), else a `.mcp.json` sitting next to
-        the config file. On a name collision the YAML `mcp_servers` entry wins, so
-        a deployment config can override individual servers from the shared file.
+        MCP servers are declared only in a `.mcp.json` file — the same
+        project-scoped format Claude Code uses — so one file serves both archi
+        and Claude. The file is the one named by the config's optional
+        `mcp_servers_file` key (resolved relative to the config file), else a
+        `.mcp.json` sitting next to the config file. A `mcp_servers:` block in
+        the YAML config is no longer read; the loaded file fully defines the set.
         """
+        if config.get("mcp_servers"):
+            logger.warning(
+                f"{config_filepath}: an 'mcp_servers:' block in the YAML config is "
+                f"no longer read — declare MCP servers in a {MCP_JSON_FILENAME} file instead"
+            )
+
         explicit = config.get("mcp_servers_file")
         if explicit:
             candidate = Path(str(explicit)).expanduser()
@@ -80,17 +88,10 @@ class ConfigurationManager:
         else:
             mcp_json_path = config_filepath.parent / MCP_JSON_FILENAME
             if not mcp_json_path.exists():
+                config["mcp_servers"] = {}
                 return
 
-        file_servers = load_mcp_json(mcp_json_path)
-        yaml_servers = config.get("mcp_servers") or {}
-        overlap = sorted(file_servers.keys() & yaml_servers.keys())
-        if overlap:
-            logger.warning(
-                f"MCP servers defined in both {mcp_json_path} and the YAML config: "
-                f"{overlap}; keeping the YAML definitions"
-            )
-        config["mcp_servers"] = {**file_servers, **yaml_servers}
+        config["mcp_servers"] = load_mcp_json(mcp_json_path)
 
     def _append(self, config):
         """Appends configuration to the config list if the static portions are equivalent to the previous one."""

--- a/src/cli/managers/config_manager.py
+++ b/src/cli/managers/config_manager.py
@@ -10,6 +10,7 @@ from src.cli.source_registry import source_registry
 from src.utils.ab_testing import ABPool, ABPoolError, load_ab_pool_state
 from src.utils.jira import parse_jira_project_keys
 from src.utils.logging import get_logger
+from src.utils.mcp_json import MCP_JSON_FILENAME, load_mcp_json
 
 logger = get_logger(__name__)
 
@@ -55,7 +56,41 @@ class ConfigurationManager:
         # Track origin for relative-path resolution (e.g., prompts).
         config["_config_path"] = str(config_filepath)
 
+        self._merge_mcp_json(config, config_filepath)
+
         return config
+
+    @staticmethod
+    def _merge_mcp_json(config: Dict[str, Any], config_filepath: Path) -> None:
+        """Merge MCP servers from a Claude-style .mcp.json into config['mcp_servers'].
+
+        The file is the one named by the config's optional `mcp_servers_file` key
+        (resolved relative to the config file), else a `.mcp.json` sitting next to
+        the config file. On a name collision the YAML `mcp_servers` entry wins, so
+        a deployment config can override individual servers from the shared file.
+        """
+        explicit = config.get("mcp_servers_file")
+        if explicit:
+            candidate = Path(str(explicit)).expanduser()
+            mcp_json_path = candidate if candidate.is_absolute() else config_filepath.parent / candidate
+            if not mcp_json_path.exists():
+                raise FileNotFoundError(
+                    f"mcp_servers_file '{explicit}' (from {config_filepath}) not found at {mcp_json_path}"
+                )
+        else:
+            mcp_json_path = config_filepath.parent / MCP_JSON_FILENAME
+            if not mcp_json_path.exists():
+                return
+
+        file_servers = load_mcp_json(mcp_json_path)
+        yaml_servers = config.get("mcp_servers") or {}
+        overlap = sorted(file_servers.keys() & yaml_servers.keys())
+        if overlap:
+            logger.warning(
+                f"MCP servers defined in both {mcp_json_path} and the YAML config: "
+                f"{overlap}; keeping the YAML definitions"
+            )
+        config["mcp_servers"] = {**file_servers, **yaml_servers}
 
     def _append(self, config):
         """Appends configuration to the config list if the static portions are equivalent to the previous one."""

--- a/src/cli/templates/base-config.yaml
+++ b/src/cli/templates/base-config.yaml
@@ -17,6 +17,9 @@ mcp_servers:
     {%- if server_config.url is defined %}
     url: {{ server_config.url }}
     {%- endif %}
+    {%- if server_config.headers is defined %}
+    headers: {{ server_config.headers | tojson }}
+    {%- endif %}
     {%- if server_config.command is defined %}
     command: {{ server_config.command }}
     {%- endif %}

--- a/src/utils/mcp_json.py
+++ b/src/utils/mcp_json.py
@@ -1,0 +1,137 @@
+"""
+Claude-style `.mcp.json` support.
+
+MCP servers can be declared in a `.mcp.json` file next to a deployment config —
+the same file format Claude Code and other MCP clients use — instead of (or in
+addition to) the YAML config's `mcp_servers:` block:
+
+    {
+      "mcpServers": {
+        "my-tools": {"type": "stdio", "command": "uvx", "args": ["mcp-server-example"]},
+        "remote":   {"type": "http", "url": "https://example.org/mcp",
+                     "headers": {"Authorization": "Bearer ${MCP_TOKEN}"}}
+      }
+    }
+
+This module owns the format: parsing/normalizing the file into archi's internal
+`mcp_servers` schema (Claude's `type` -> langchain's `transport`), and the
+`${VAR}` / `${VAR:-default}` placeholder expansion applied to connection fields
+at client-connect time. Archi-only fields (`path`, `host_file_mounts`,
+`env_from_secrets`, `build_context`, `image`, `skill`) may appear in entries and
+pass through untouched — MCP clients like Claude Code ignore unknown fields, so
+one `.mcp.json` can serve both.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+MCP_JSON_FILENAME = ".mcp.json"
+
+# Claude-style `type` values -> langchain-mcp-adapters transport names. archi's
+# native `transport` values are accepted too (identity entries).
+_TYPE_TO_TRANSPORT = {
+    "stdio": "stdio",
+    "http": "streamable_http",
+    "streamable-http": "streamable_http",
+    "streamable_http": "streamable_http",
+    "sse": "sse",
+    "websocket": "websocket",
+}
+
+# ${VAR} or ${VAR:-default} (Claude Code's expansion syntax).
+_PLACEHOLDER_RE = re.compile(
+    r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
+
+
+def expand_env_placeholders(value: Any, env: Mapping[str, str]) -> Any:
+    """Recursively expand ``${VAR}`` / ``${VAR:-default}`` in strings, lists and
+    dict values; other types pass through unchanged.
+
+    Raises ValueError naming the variable when it is unset and has no default,
+    so a misconfigured server fails loudly at connect time instead of quietly
+    sending a literal ``${TOKEN}`` in its URL or headers.
+    """
+    if isinstance(value, str):
+
+        def _sub(match: re.Match) -> str:
+            name = match.group("name")
+            if name in env:
+                return env[name]
+            default = match.group("default")
+            if default is not None:
+                return default
+            raise ValueError(
+                f"environment variable '{name}' referenced as ${{{name}}} is not set "
+                f"and has no ':-' default"
+            )
+
+        return _PLACEHOLDER_RE.sub(_sub, value)
+    if isinstance(value, list):
+        return [expand_env_placeholders(item, env) for item in value]
+    if isinstance(value, dict):
+        return {key: expand_env_placeholders(item, env) for key, item in value.items()}
+    return value
+
+
+def _normalize_server(name: str, entry: Any) -> Dict[str, Any]:
+    """Translate one mcpServers entry into archi's internal server schema."""
+    if not isinstance(entry, dict):
+        raise ValueError(f"mcpServers['{name}'] must be an object, got {type(entry).__name__}")
+    # JSON has no comment syntax; keys starting with "_" are documentation and
+    # are dropped here so they never reach the MCP client.
+    cfg = {key: value for key, value in entry.items() if not key.startswith("_")}
+    raw = cfg.pop("type", None) or cfg.get("transport")
+    if raw is None:
+        # Claude Code infers stdio from `command`; extend the same courtesy to `url`.
+        raw = "stdio" if "command" in cfg else ("http" if "url" in cfg else None)
+    if raw is None:
+        raise ValueError(
+            f"mcpServers['{name}'] needs a 'type' ('stdio', 'http' or 'sse'), "
+            f"or a 'command'/'url' field to infer it from"
+        )
+    transport = _TYPE_TO_TRANSPORT.get(str(raw).strip().lower())
+    if transport is None:
+        raise ValueError(
+            f"mcpServers['{name}'] has unsupported type/transport '{raw}' "
+            f"(supported: {sorted(set(_TYPE_TO_TRANSPORT))})"
+        )
+    cfg["transport"] = transport
+    if transport == "stdio" and not cfg.get("command"):
+        raise ValueError(f"mcpServers['{name}'] is a stdio server but has no 'command'")
+    if transport != "stdio" and not cfg.get("url"):
+        raise ValueError(f"mcpServers['{name}'] is a {transport} server but has no 'url'")
+    return cfg
+
+
+def load_mcp_json(path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load a Claude-style .mcp.json and return archi-schema server definitions.
+
+    Placeholders are NOT expanded here: the file is read on the deploy host, but
+    ``${VAR}`` values (tokens, endpoints) belong to the runtime container env —
+    expansion happens in initialize_mcp_client, so secrets never get baked into
+    rendered configs.
+    """
+    path = Path(path)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read MCP config {path}: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("mcpServers"), dict):
+        raise ValueError(
+            f"{path} must be a JSON object with an 'mcpServers' object "
+            f"(the Claude .mcp.json format)"
+        )
+    servers = {
+        name: _normalize_server(name, entry) for name, entry in data["mcpServers"].items()
+    }
+    logger.info("Loaded %d MCP server(s) from %s: %s", len(servers), path, sorted(servers))
+    return servers

--- a/src/utils/mcp_json.py
+++ b/src/utils/mcp_json.py
@@ -1,9 +1,9 @@
 """
 Claude-style `.mcp.json` support.
 
-MCP servers can be declared in a `.mcp.json` file next to a deployment config —
-the same file format Claude Code and other MCP clients use — instead of (or in
-addition to) the YAML config's `mcp_servers:` block:
+MCP servers are declared in a `.mcp.json` file next to a deployment config —
+the same project-scoped file format Claude Code and other MCP clients use, so
+one file serves both archi and Claude:
 
     {
       "mcpServers": {

--- a/tests/unit/test_mcp_json.py
+++ b/tests/unit/test_mcp_json.py
@@ -1,0 +1,181 @@
+import json
+
+import pytest
+import yaml
+
+from src.cli.managers.config_manager import ConfigurationManager
+from src.utils.mcp_json import expand_env_placeholders, load_mcp_json
+
+
+# ---------------------------------------------------------------------------
+# load_mcp_json: Claude-format parsing + translation into archi's schema
+# ---------------------------------------------------------------------------
+
+def _write_mcp_json(tmp_path, servers, filename=".mcp.json"):
+    path = tmp_path / filename
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return path
+
+
+def test_load_translates_claude_types(tmp_path):
+    path = _write_mcp_json(tmp_path, {
+        "local-tools": {"type": "stdio", "command": "uvx", "args": ["mcp-server-example"]},
+        "remote": {"type": "http", "url": "https://example.org/mcp",
+                   "headers": {"Authorization": "Bearer ${TOKEN}"}},
+        "events": {"type": "sse", "url": "http://localhost:8080/sse"},
+    })
+    servers = load_mcp_json(path)
+    assert servers["local-tools"]["transport"] == "stdio"
+    assert servers["local-tools"]["command"] == "uvx"
+    assert "type" not in servers["local-tools"]
+    assert servers["remote"]["transport"] == "streamable_http"
+    assert servers["remote"]["headers"] == {"Authorization": "Bearer ${TOKEN}"}  # NOT expanded at load
+    assert servers["events"]["transport"] == "sse"
+
+
+def test_load_infers_type_from_fields(tmp_path):
+    path = _write_mcp_json(tmp_path, {
+        "inferred-stdio": {"command": "python", "args": ["-m", "server"]},
+        "inferred-http": {"url": "https://example.org/mcp"},
+    })
+    servers = load_mcp_json(path)
+    assert servers["inferred-stdio"]["transport"] == "stdio"
+    assert servers["inferred-http"]["transport"] == "streamable_http"
+
+
+def test_load_accepts_archi_native_transport_and_extras(tmp_path):
+    path = _write_mcp_json(tmp_path, {
+        "in-container": {
+            "transport": "stdio", "command": "python", "args": ["-m", "pkg"],
+            "path": "/host/pkg", "host_file_mounts": ["/host/cfg.json"], "skill": "pkg-skill",
+        },
+    })
+    servers = load_mcp_json(path)
+    cfg = servers["in-container"]
+    assert cfg["transport"] == "stdio"
+    assert cfg["path"] == "/host/pkg"
+    assert cfg["host_file_mounts"] == ["/host/cfg.json"]
+    assert cfg["skill"] == "pkg-skill"
+
+
+@pytest.mark.parametrize("entry, match", [
+    ({"type": "carrier-pigeon", "url": "x"}, "unsupported type"),
+    ({"type": "stdio"}, "no 'command'"),
+    ({"type": "http"}, "no 'url'"),
+    ({"env": {"A": "b"}}, "needs a 'type'"),
+    ("not-an-object", "must be an object"),
+])
+def test_load_rejects_bad_entries(tmp_path, entry, match):
+    path = _write_mcp_json(tmp_path, {"bad": entry})
+    with pytest.raises(ValueError, match=match):
+        load_mcp_json(path)
+
+
+def test_load_drops_underscore_comment_keys(tmp_path):
+    path = _write_mcp_json(tmp_path, {
+        "documented": {"_comment": "why this server exists", "type": "http", "url": "http://x/mcp"},
+    })
+    servers = load_mcp_json(path)
+    assert "_comment" not in servers["documented"]
+
+
+def test_load_rejects_missing_mcp_servers_key(tmp_path):
+    path = tmp_path / ".mcp.json"
+    path.write_text(json.dumps({"servers": {}}))
+    with pytest.raises(ValueError, match="mcpServers"):
+        load_mcp_json(path)
+
+
+# ---------------------------------------------------------------------------
+# expand_env_placeholders: ${VAR} / ${VAR:-default}
+# ---------------------------------------------------------------------------
+
+def test_expand_basic_and_default():
+    env = {"TOKEN": "s3cret"}
+    assert expand_env_placeholders("Bearer ${TOKEN}", env) == "Bearer s3cret"
+    assert expand_env_placeholders("${MISSING:-fallback}", env) == "fallback"
+    assert expand_env_placeholders("${MISSING:-}", env) == ""
+
+
+def test_expand_recurses_and_preserves_non_strings():
+    env = {"HOST": "example.org", "PORT": "8080"}
+    cfg = {
+        "url": "https://${HOST}:${PORT}/mcp",
+        "headers": {"X-Token": "${MISSING:-anon}"},
+        "args": ["--endpoint", "${HOST}"],
+        "timeout": 30,
+        "flag": True,
+    }
+    expanded = expand_env_placeholders(cfg, env)
+    assert expanded["url"] == "https://example.org:8080/mcp"
+    assert expanded["headers"] == {"X-Token": "anon"}
+    assert expanded["args"] == ["--endpoint", "example.org"]
+    assert expanded["timeout"] == 30 and expanded["flag"] is True
+
+
+def test_expand_missing_without_default_raises():
+    with pytest.raises(ValueError, match="NOPE"):
+        expand_env_placeholders("${NOPE}", {})
+
+
+def test_expand_leaves_non_placeholder_dollars_alone():
+    env = {}
+    assert expand_env_placeholders("cost is $5 and ${}", env) == "cost is $5 and ${}"
+
+
+# ---------------------------------------------------------------------------
+# ConfigurationManager: discovery + merge precedence
+# ---------------------------------------------------------------------------
+
+def _write_yaml(tmp_path, config, filename="config.yaml"):
+    path = tmp_path / filename
+    path.write_text(yaml.safe_dump(config))
+    return path
+
+
+def test_config_manager_merges_adjacent_mcp_json(tmp_path):
+    config_path = _write_yaml(tmp_path, {"name": "test", "services": {}})
+    _write_mcp_json(tmp_path, {"from-file": {"type": "http", "url": "http://x/mcp"}})
+    manager = ConfigurationManager([str(config_path)], env=None)
+    servers = manager.config["mcp_servers"]
+    assert servers["from-file"]["transport"] == "streamable_http"
+
+
+def test_config_manager_yaml_wins_on_collision(tmp_path):
+    config_path = _write_yaml(tmp_path, {
+        "name": "test", "services": {},
+        "mcp_servers": {"shared": {"transport": "streamable_http", "url": "http://yaml/mcp"},
+                        "yaml-only": {"transport": "stdio", "command": "python"}},
+    })
+    _write_mcp_json(tmp_path, {"shared": {"type": "http", "url": "http://json/mcp"},
+                               "json-only": {"type": "http", "url": "http://json2/mcp"}})
+    manager = ConfigurationManager([str(config_path)], env=None)
+    servers = manager.config["mcp_servers"]
+    assert servers["shared"]["url"] == "http://yaml/mcp"
+    assert set(servers) == {"shared", "yaml-only", "json-only"}
+
+
+def test_config_manager_explicit_mcp_servers_file(tmp_path):
+    _write_mcp_json(tmp_path, {"custom": {"type": "http", "url": "http://x/mcp"}},
+                    filename="my-servers.json")
+    config_path = _write_yaml(tmp_path, {
+        "name": "test", "services": {}, "mcp_servers_file": "my-servers.json",
+    })
+    manager = ConfigurationManager([str(config_path)], env=None)
+    assert "custom" in manager.config["mcp_servers"]
+
+
+def test_config_manager_missing_explicit_file_fails_load(tmp_path):
+    config_path = _write_yaml(tmp_path, {
+        "name": "test", "services": {}, "mcp_servers_file": "does-not-exist.json",
+    })
+    # _load_config failures are caught per-file; with a single bad config the
+    # manager ends up with no configs at all.
+    with pytest.raises(AssertionError):
+        ConfigurationManager([str(config_path)], env=None)
+
+
+def test_config_manager_no_mcp_json_leaves_config_untouched(tmp_path):
+    config_path = _write_yaml(tmp_path, {"name": "test", "services": {}})
+    manager = ConfigurationManager([str(config_path)], env=None)
+    assert "mcp_servers" not in manager.config

--- a/tests/unit/test_mcp_json.py
+++ b/tests/unit/test_mcp_json.py
@@ -124,7 +124,7 @@ def test_expand_leaves_non_placeholder_dollars_alone():
 
 
 # ---------------------------------------------------------------------------
-# ConfigurationManager: discovery + merge precedence
+# ConfigurationManager: .mcp.json discovery
 # ---------------------------------------------------------------------------
 
 def _write_yaml(tmp_path, config, filename="config.yaml"):
@@ -141,18 +141,16 @@ def test_config_manager_merges_adjacent_mcp_json(tmp_path):
     assert servers["from-file"]["transport"] == "streamable_http"
 
 
-def test_config_manager_yaml_wins_on_collision(tmp_path):
+def test_config_manager_yaml_block_ignored(tmp_path):
+    # A stale `mcp_servers:` block in the YAML is no longer read; the .mcp.json
+    # fully defines the set.
     config_path = _write_yaml(tmp_path, {
         "name": "test", "services": {},
-        "mcp_servers": {"shared": {"transport": "streamable_http", "url": "http://yaml/mcp"},
-                        "yaml-only": {"transport": "stdio", "command": "python"}},
+        "mcp_servers": {"yaml-only": {"transport": "stdio", "command": "python"}},
     })
-    _write_mcp_json(tmp_path, {"shared": {"type": "http", "url": "http://json/mcp"},
-                               "json-only": {"type": "http", "url": "http://json2/mcp"}})
+    _write_mcp_json(tmp_path, {"from-file": {"type": "http", "url": "http://json/mcp"}})
     manager = ConfigurationManager([str(config_path)], env=None)
-    servers = manager.config["mcp_servers"]
-    assert servers["shared"]["url"] == "http://yaml/mcp"
-    assert set(servers) == {"shared", "yaml-only", "json-only"}
+    assert set(manager.config["mcp_servers"]) == {"from-file"}
 
 
 def test_config_manager_explicit_mcp_servers_file(tmp_path):
@@ -175,7 +173,17 @@ def test_config_manager_missing_explicit_file_fails_load(tmp_path):
         ConfigurationManager([str(config_path)], env=None)
 
 
-def test_config_manager_no_mcp_json_leaves_config_untouched(tmp_path):
+def test_config_manager_no_mcp_json_yields_empty(tmp_path):
     config_path = _write_yaml(tmp_path, {"name": "test", "services": {}})
     manager = ConfigurationManager([str(config_path)], env=None)
-    assert "mcp_servers" not in manager.config
+    assert manager.config["mcp_servers"] == {}
+
+
+def test_config_manager_yaml_block_without_json_yields_empty(tmp_path):
+    # No .mcp.json present: a YAML `mcp_servers:` block is dropped, not used.
+    config_path = _write_yaml(tmp_path, {
+        "name": "test", "services": {},
+        "mcp_servers": {"yaml-only": {"transport": "stdio", "command": "python"}},
+    })
+    manager = ConfigurationManager([str(config_path)], env=None)
+    assert manager.config["mcp_servers"] == {}


### PR DESCRIPTION
## Fixes

**`RecursionError` on every MCP tool call** (3a748da)

langchain-mcp-adapters (0.1.11) sets each tool's `args_schema` to the MCP
server's raw JSON-schema *dict* rather than a pydantic model. langchain-core
(1.2.13) then calls `get_all_basemodel_annotations()` on it, which recurses on
`get_origin(cls)` — for a dict (then `None`) that never terminates.

It's caught and logged at DEBUG so it's non-fatal, but it burns ~1000 stack
frames per call and floods the logs. We install a guarded
`get_all_basemodel_annotations` at MCP-client init that adds the missing base
case: a non-type with no generic origin returns no annotations instead of
recursing. Real pydantic `args_schema` models are unaffected. The patch is
idempotent and safe to call on every init.

**Concurrent tool calls corrupt the shared MCP session** (dc0df0e, 390564a)

All MCP tools share one client/session on a single background loop, so when the
model emits parallel tool calls they hit that session at once — corrupting
response routing and leaking server-side connections.

This needed locks on *both* paths, which is why it's two commits: the threading
lock covers the sync wrapper (`stream`), but `astream` invokes the tool
coroutine directly on the MCP session loop, where parallel calls run as
concurrent coroutines rather than blocking threads and so slip past a threading
lock entirely. The second commit wraps the coroutine in an asyncio lock and
moves tool-input recording inside it, so both paths record exactly once.

## Feature: `.mcp.json` server definitions (674e8ad)

MCP servers can now be declared in a `.mcp.json` next to the deployment config —
the project-scoped format Claude Code uses — instead of or alongside the YAML
`mcp_servers:` block.

- `src/utils/mcp_json.py` owns the format: parses `{"mcpServers": ...}`, maps
  Claude `type` (stdio/http/sse) onto langchain transports (`http` →
  `streamable_http`), infers type from `command`/`url` when omitted, validates
  per-transport required fields, and drops `_`-prefixed comment keys.
- archi-only fields (`path`, `host_file_mounts`, `env_from_secrets`,
  `build_context`, `image`, `skill`) pass through untouched, so a single file
  can serve both archi and Claude Code.
- `ConfigurationManager` discovers `.mcp.json` beside each config file (or the
  file named by an explicit `mcp_servers_file:` key) and merges it into
  `config['mcp_servers']`. **YAML entries win on name collision**, with a
  warning, so a deployment config can override individual shared servers.
- `${VAR}` / `${VAR:-default}` placeholders expand at connect time against the
  container env — so secrets in `url`/`headers`/`env` come from the environment
  instead of being baked into rendered configs. Expansion runs *before* the
  stdio `os.environ` merge, so only declared values are expanded, never the
  inherited host env. An unset variable with no default disables that server
  with a logged error rather than failing the whole client.
- `base-config.yaml` now renders `headers`, so HTTP auth survives into the
  seeded runtime config.