### PR TITLE
W2: packaging + auth (stack completion after out-of-order merges)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/smoke/test_playbooks_integration.py
 tests/ui/playbooks.spec.ts
 .claude/
 .okg/
+python/dist/

--- a/pact/changes/w2-consolidate-hep-sources/pact.yaml
+++ b/pact/changes/w2-consolidate-hep-sources/pact.yaml
@@ -4,19 +4,16 @@ change:
   id: w2-consolidate-hep-sources
   title: 'W2: consolidate HEP sources into the archi package'
   status: proposal
-  rationale: >-
-    ADR 0001 W2: the domain layer is consolidation, not construction. The HEP
-    source code exists in three places — okg-deployments/cms/cms_sources/
-    (22 adapter classes, 9,328 LOC), archi origin/dev's Scrapy layer (the
-    current scraper design), and cooper (deferred) — and TWiki parsing alone
-    exists three times. This change consolidates it into the pip-installable
-    archi package proven by w1-prove-the-seam, per the porting matrix
-    (porting-matrix.md in this change).
-  root_cause: >-
-    v2 scattered HEP ingestion across archi's collectors, agent tools, and the
-    CMS OKG deployment's local package; nothing is shareable across instances
-    without copy-paste (the wisdqm _cache.py and TWiki-parser forks are the
-    live evidence).
+  rationale: "ADR 0001 W2: the domain layer is consolidation, not construction. The\
+    \ HEP source code exists in three places \u2014 okg-deployments/cms/cms_sources/\
+    \ (22 adapter classes, 9,328 LOC), archi origin/dev's Scrapy layer (the current\
+    \ scraper design), and cooper (deferred) \u2014 and TWiki parsing alone exists\
+    \ three times. This change consolidates it into the pip-installable archi package\
+    \ proven by w1-prove-the-seam, per the porting matrix (porting-matrix.md in this\
+    \ change)."
+  root_cause: v2 scattered HEP ingestion across archi's collectors, agent tools, and
+    the CMS OKG deployment's local package; nothing is shareable across instances
+    without copy-paste (the wisdqm _cache.py and TWiki-parser forks are the live evidence).
   affected_areas:
   - python/
   - pact/changes/w2-consolidate-hep-sources
@@ -25,10 +22,9 @@ change:
 requirements:
 - id: req.w2.packaging
   title: v3 package builds without touching the v2 build
-  statement: >-
-    The archi v3 distribution builds as a wheel from python/ (its own
-    pyproject) while the v2 root build (setup.py/pyproject.toml, src/) remains
-    untouched and v2 unit tests keep passing on archi_v3.
+  statement: The archi v3 distribution builds as a wheel from python/ (its own pyproject)
+    while the v2 root build (setup.py/pyproject.toml, src/) remains untouched and
+    v2 unit tests keep passing on archi_v3.
   evidence_policy:
     required:
     - executed_test
@@ -44,16 +40,19 @@ requirements:
     and: []
   acceptance:
   - id: acc.w2.packaging
-    description: CI builds the python/ wheel and runs existing tests/unit/ green in the same pipeline.
+    description: python/tests/test_packaging.py passes (wheel builds from python/,
+      v3 never imports v2, schema data ships in the wheel, no operator paths, root
+      build files untouched). CI wiring is deferred by maintainer decision (2026-08-11,
+      "let's not worry about those actions for now") and returns with the OKG_REPO_TOKEN
+      secret.
     evidence:
     - executed_test
 - id: req.w2.auth
   title: CERN auth plumbing is package code, credentials are instance data
-  statement: >-
-    archi/auth/ consolidates the preflight probes, CERN SSO flows, and the
-    cache utility; no module contains a hardcoded operator path (/Users/,
-    /root/, /home/ literals) or a credential value; credentials arrive only by
-    environment/credential_refs indirection.
+  statement: archi/auth/ consolidates the preflight probes, CERN SSO flows, and the
+    cache utility; no module contains a hardcoded operator path (/Users/, /root/,
+    /home/ literals) or a credential value; credentials arrive only by environment/credential_refs
+    indirection.
   evidence_policy:
     required:
     - executed_test
@@ -69,18 +68,18 @@ requirements:
     and: []
   acceptance:
   - id: acc.w2.auth
-    description: A lint test asserts no hardcoded operator paths or credential literals in python/archi.
+    description: A lint test asserts no hardcoded operator paths or credential literals
+      in python/archi.
     evidence:
     - executed_test
 - id: req.w2.sources
   title: The source families port against the current adapter contract
-  statement: >-
-    Every source in the porting matrix lands rewritten against the current
-    SourceAdapter + registry contract (sound change probe, producer authority,
-    admission mode), with offline unit tests, a documented registry-entry
-    template, and okg deployment lint green on a scratch registry entry. The
-    parity families (jira, docsite, gitlab_docs) come first; the TWiki
-    three-way merge produces exactly one parser.
+  statement: Every source in the porting matrix lands rewritten against the current
+    SourceAdapter + registry contract (sound change probe, producer authority, admission
+    mode), with offline unit tests, a documented registry-entry template, and okg
+    deployment lint green on a scratch registry entry. The parity families (jira,
+    docsite, gitlab_docs) come first; the TWiki three-way merge produces exactly one
+    parser.
   evidence_policy:
     required:
     - executed_test
@@ -96,19 +95,17 @@ requirements:
     and: []
   acceptance:
   - id: acc.w2.sources
-    description: >-
-      Per-source fixture-driven unit tests pass offline; at least the parity
-      families demonstrate a scratch-instance ingest cycle; provenance
-      (source repo + ref + what changed) is recorded per port.
+    description: Per-source fixture-driven unit tests pass offline; at least the parity
+      families demonstrate a scratch-instance ingest cycle; provenance (source repo
+      + ref + what changed) is recorded per port.
     evidence:
     - executed_test
 - id: req.w2.enrichment
   title: Enrichers and identifier/link defaults are importable package data
-  statement: >-
-    The five CMS enrichers, the alias backend, and the extractor/linker/
-    identifier-pattern defaults move into archi/enrichment/, consumable by an
-    instance's config as selectable defaults (wisdqm's DQM patterns included —
-    the second call site exists).
+  statement: "The five CMS enrichers, the alias backend, and the extractor/linker/\
+    \ identifier-pattern defaults move into archi/enrichment/, consumable by an instance's\
+    \ config as selectable defaults (wisdqm's DQM patterns included \u2014 the second\
+    \ call site exists)."
   evidence_policy:
     required:
     - executed_test
@@ -124,15 +121,15 @@ requirements:
     and: []
   acceptance:
   - id: acc.w2.enrichment
-    description: Unit tests load the defaults from the installed wheel and validate their shape.
+    description: Unit tests load the defaults from the installed wheel and validate
+      their shape.
     evidence:
     - executed_test
 - id: req.w2.compops-unbroken
   title: The comp-ops instance stays green throughout
-  statement: >-
-    W2 does not switch okg-deployments/cms to the package (that is W7); its
-    lint and checks must pass unchanged at every W2 merge (ADR 0001 D10 —
-    breaking comp-ops is a blocking regression).
+  statement: "W2 does not switch okg-deployments/cms to the package (that is W7);\
+    \ its lint and checks must pass unchanged at every W2 merge (ADR 0001 D10 \u2014\
+    \ breaking comp-ops is a blocking regression)."
   evidence_policy:
     required:
     - executed_test
@@ -148,13 +145,14 @@ requirements:
     and: []
   acceptance:
   - id: acc.w2.compops
-    description: The comp-ops lint baseline is recorded before W2 starts and re-checked per merge.
+    description: The comp-ops lint baseline is recorded before W2 starts and re-checked
+      per merge.
     evidence:
     - executed_test
 tasks:
 - id: task.w2.packaging
   title: python/ package skeleton + CI wheel lane
-  status: todo
+  status: done
   verification: python/tests/test_packaging.py
   requirements:
   - req.w2.packaging
@@ -166,7 +164,7 @@ tasks:
     description: CI secret for okg-dependent test lanes (Luca to add to the repo).
     required: false
 - id: task.w2.auth
-  title: archi/auth — preflight, SSO, cache util
+  title: "archi/auth \u2014 preflight, SSO, cache util"
   status: todo
   verification: python/tests/auth/
   requirements:
@@ -198,7 +196,8 @@ tasks:
   evidence: []
   environment: []
 - id: task.w2.sources-catalogs
-  title: 'Catalogs: cric, cmssw (merge W1 spike), dbs, conddb, dqm, gocdb, siteconf, wmstats, github_repos, hypernews, indico'
+  title: 'Catalogs: cric, cmssw (merge W1 spike), dbs, conddb, dqm, gocdb, siteconf,
+    wmstats, github_repos, hypernews, indico'
   status: todo
   verification: python/tests/sources/
   requirements:
@@ -206,7 +205,7 @@ tasks:
   evidence: []
   environment: []
 - id: task.w2.enrichment
-  title: archi/enrichment — enrichers, alias backend, defaults
+  title: "archi/enrichment \u2014 enrichers, alias backend, defaults"
   status: todo
   verification: python/tests/enrichment/
   requirements:
@@ -221,11 +220,7 @@ tasks:
   - req.w2.compops-unbroken
   evidence: []
   environment: []
-dependencies:
-- from: task.w2.packaging
-  to: task.w1-prove-the-seam
-  kind: requires
-  rationale: The python/ package seeds from the w1-prove-the-seam spike.
+dependencies: []
 test_plan:
 - id: test.req-w2-packaging.python-tests-test-packaging
   requirement: req.w2.packaging
@@ -254,4 +249,28 @@ test_plan:
   - graph_report
 formal: []
 waivers: []
-evidence: []
+evidence:
+- id: ev.pytest.req-w2-packaging.20260811T210431898899Z
+  kind: pytest
+  status: pass
+  refs:
+  - req.w2.packaging
+  artifact: python/tests/test_packaging.py
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
+    -q
+  summary: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema
+    ships in wheel, no operator paths, root build untouched'
+  data:
+    attached_at: '2026-08-11T21:04:31.898947+00:00'
+- id: ev.pytest.req-w2-packaging.20260811T210527248898Z
+  kind: pytest
+  status: pass
+  refs:
+  - req.w2.packaging
+  artifact: python/tests/test_packaging.py
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
+    -q
+  summary: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema
+    ships in wheel, no operator paths, root build untouched'
+  data:
+    attached_at: '2026-08-11T21:05:27.249012+00:00'

--- a/pact/changes/w2-consolidate-hep-sources/pact.yaml
+++ b/pact/changes/w2-consolidate-hep-sources/pact.yaml
@@ -165,7 +165,7 @@ tasks:
     required: false
 - id: task.w2.auth
   title: "archi/auth \u2014 preflight, SSO, cache util"
-  status: todo
+  status: done
   verification: python/tests/auth/
   requirements:
   - req.w2.auth
@@ -274,3 +274,25 @@ evidence:
     ships in wheel, no operator paths, root build untouched'
   data:
     attached_at: '2026-08-11T21:05:27.249012+00:00'
+- id: ev.pytest.req-w2-auth.20260812T003827308891Z
+  kind: pytest
+  status: pass
+  refs:
+  - req.w2.auth
+  artifact: python/tests/auth/
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth/ -q
+  summary: 46/46 auth tests incl. review-fix regressions; no-operator-paths lint green
+    in packaging suite
+  data:
+    attached_at: '2026-08-12T00:38:27.308914+00:00'
+- id: ev.pytest.req-w2-auth.20260812T003850633918Z
+  kind: pytest
+  status: pass
+  refs:
+  - req.w2.auth
+  artifact: python/tests/auth/
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth/ -q
+  summary: 45/45 auth tests incl. two review-fix regressions (corrects prior entry's
+    46/46 typo); no-operator-paths lint green in packaging suite
+  data:
+    attached_at: '2026-08-12T00:38:50.633941+00:00'

--- a/pact/changes/w2-consolidate-hep-sources/porting-matrix.md
+++ b/pact/changes/w2-consolidate-hep-sources/porting-matrix.md
@@ -36,7 +36,7 @@ spike (`pact/changes/w1-prove-the-seam/spike/`) is the seed: its
 | `hypernews.py` (586) | `archi/sources/hypernews.py` | discovery_crawl | cookie | forum threads. |
 | `github_repos.py` (193) | `archi/sources/github_repos.py` | reference_catalog | `GITHUB_TOKEN` (optional) | repo identity nodes. |
 | `preflight.py` CMSPreflightSource (674) | `archi/auth/preflight.py` | live_overlay | the whole credential surface | emits no graph facts; generic CERN auth probes (SSO cookie, X509, TLS, tokens). |
-| `_cache.py` (207) | `archi/sources/_cache.py` | — | — | unify the wisdqm 55-LOC fork; keep `resolve_repo_path` deployment-relative (no hardcoded operator paths — lint for `/Users/`, `/root/`, `/home/` literals). |
+| `_cache.py` (207) | `archi/auth/cache.py` (landed there with task.w2.auth; matrix originally said `archi/sources/_cache.py`) | — | — | unified with the wisdqm 55-LOC fork; `resolve_repo_path` base is explicit param → `ARCHI_DATA_ROOT` → cwd (no repo-layout assumptions, no hardcoded operator paths). `json_record_count`/`cache_preflight_result`/`cache_source_health` deliberately dropped — they move with the individual source ports. |
 | `alias.py` CMSProjectionAliasBackend (192) | `archi/enrichment/alias.py` | — | — | type-aware alias resolution. |
 
 ## From archi v2 (take `origin/dev` for anything scraper-shaped)

--- a/profiles/w1-scratch/_live/ingest.2156771.json
+++ b/profiles/w1-scratch/_live/ingest.2156771.json
@@ -1,0 +1,38 @@
+{
+  "deployment": "w1-scratch",
+  "duration_ms": 3074.121476,
+  "limitations": [],
+  "pid": 2156771,
+  "policy": {
+    "deep_capture": {
+      "collectors": [],
+      "max_bundles": 20,
+      "mode": "manual",
+      "sample_rate": 0.0,
+      "slow_mcp_ms": 1000,
+      "slow_publish_ms": 30000,
+      "slow_viz_request_ms": 1000,
+      "targets": [
+        "publish",
+        "mcp",
+        "viz-request"
+      ]
+    },
+    "lightweight": {
+      "enabled": true,
+      "live_snapshot_stale_seconds": 60,
+      "ring_buffer_events": 10000,
+      "slow_query_ms": 250,
+      "wait_sample_hz": 2.0
+    }
+  },
+  "profile_run_id": "eb1f52dc33df",
+  "slow_queries": [],
+  "stage_p95_ms": {
+    "ingest.publish.commit": 1002.397768,
+    "source.bootstrap-fixture.run": 1892.595061,
+    "source.cmssw-releases.run": 1987.839805
+  },
+  "target_kind": "ingest",
+  "updated_at": "2026-08-11T21:05:51.244502+00:00"
+}

--- a/python/archi/__init__.py
+++ b/python/archi/__init__.py
@@ -1,0 +1,13 @@
+"""Archi — the HEP distribution of OKG.
+
+Ships the HEP schemas, source adapters, enrichment, live tools, skills,
+bundles, and evaluation suite that turn a blank OKG install into a
+working HEP instance (ADR 0001). Holds no credentials, no site
+configuration, and no running services.
+
+okg is a host dependency, deliberately not declared here: adapters are
+imported *by* an OKG deployment (`module: archi.sources.<name>` in its
+source registry), so the substrate is always already present.
+"""
+
+__version__ = "3.0.0a1"

--- a/python/archi/auth/__init__.py
+++ b/python/archi/auth/__init__.py
@@ -1,0 +1,45 @@
+"""CERN auth plumbing: cache helpers, cookie files, credential preflight.
+
+Consolidates the auth-adjacent utilities every CERN-facing source
+needs: cache path/hash/probe helpers (:mod:`archi.auth.cache`), SSO
+cookie-file handling (:mod:`archi.auth.cookies`), and the
+credential/reachability preflight source (:mod:`archi.auth.preflight`).
+Rewritten from okg-deployments ``main@f33a9c4`` (``cms/cms_sources/``,
+``wisdqm/wisdqm_sources/``) and archi ``dev@28b977d1``; per-module
+docstrings record what changed.
+"""
+from archi.auth.cache import (
+    DATA_ROOT_ENV,
+    cache_or_forced_live_change_probe,
+    content_hash,
+    content_hash_change_probe,
+    data_root,
+    load_json,
+    resolve_repo_path,
+)
+from archi.auth.cookies import (
+    CookieFileStatus,
+    check_cookie_file,
+    load_cookie_jar,
+    looks_like_login_page,
+    looks_like_login_url,
+    sso_cookie_acquisition_command,
+)
+from archi.auth.preflight import CERNPreflightSource
+
+__all__ = [
+    "CERNPreflightSource",
+    "CookieFileStatus",
+    "DATA_ROOT_ENV",
+    "cache_or_forced_live_change_probe",
+    "check_cookie_file",
+    "content_hash",
+    "content_hash_change_probe",
+    "data_root",
+    "load_cookie_jar",
+    "load_json",
+    "looks_like_login_page",
+    "looks_like_login_url",
+    "resolve_repo_path",
+    "sso_cookie_acquisition_command",
+]

--- a/python/archi/auth/cache.py
+++ b/python/archi/auth/cache.py
@@ -1,0 +1,137 @@
+"""Cache-file helpers for cache-backed Archi sources.
+
+Rewritten from okg-deployments ``cms/cms_sources/_cache.py`` (207 LOC)
+unified with its trimmed fork ``wisdqm/wisdqm_sources/_cache.py``
+(55 LOC), both at ``main@f33a9c4``. Changes from the originals:
+
+- ``resolve_repo_path`` no longer assumes it runs inside a deployments
+  repo checkout (the originals walked up to a hardcoded repo root). The
+  base directory is now explicit: a ``base`` argument, else the
+  ``ARCHI_DATA_ROOT`` environment variable, else the current working
+  directory.
+- The per-deployment ``data/<name>`` prefix stripping
+  (``OKG_CMS_DATA_ROOT`` / ``OKG_WISDQM_DATA_ROOT``) is dropped;
+  instances point ``ARCHI_DATA_ROOT`` at whichever directory their
+  relative cache paths are written against.
+- The cache preflight/health helpers (``cache_preflight_result``,
+  ``cache_source_health``, ``json_record_count``) are not ported here;
+  they move with the source ports that consume them.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
+from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+
+DATA_ROOT_ENV = "ARCHI_DATA_ROOT"
+
+
+def data_root(base: str | Path | None = None) -> Path:
+    """Return the directory relative cache paths resolve against."""
+    if base is not None:
+        return Path(base).expanduser()
+    raw = os.environ.get(DATA_ROOT_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.cwd()
+
+
+def resolve_repo_path(
+    path: str | Path,
+    *,
+    base: str | Path | None = None,
+) -> Path:
+    p = Path(path).expanduser()
+    if p.is_absolute():
+        return p
+    return data_root(base) / p
+
+
+def load_json(path: str | Path, *, base: str | Path | None = None) -> Any:
+    p = resolve_repo_path(path, base=base)
+    with p.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def content_hash(
+    paths: Iterable[str | Path],
+    *,
+    base: str | Path | None = None,
+) -> str:
+    digest = hashlib.sha256()
+    resolved = sorted((str(p), resolve_repo_path(p, base=base)) for p in paths)
+    for label, path in resolved:
+        digest.update(label.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def content_hash_change_probe(
+    *,
+    cache_paths: Iterable[str | Path],
+    config: dict[str, Any],
+    emit_targets: Any,
+    base: str | Path | None = None,
+) -> ContentHashProbe:
+    """Change probe over cache files that exist at probe time."""
+    paths = tuple(cache_paths)
+
+    def _items() -> list[tuple[str, Path]]:
+        out: list[tuple[str, Path]] = []
+        for raw in paths:
+            path = resolve_repo_path(raw, base=base)
+            if path.is_file():
+                out.append((str(raw), path))
+        return out
+
+    return ContentHashProbe(
+        content_items=_items,
+        config=config,
+        emit_targets=emit_targets,
+    )
+
+
+def cache_or_forced_live_change_probe(
+    *,
+    cache_paths: Iterable[str | Path],
+    config: dict[str, Any],
+    emit_targets: Any,
+    base: str | Path | None = None,
+) -> MutableApiProbe:
+    """Probe mutable sources that have cache artifacts but no cheap live token.
+
+    When a cache exists, use its content hash as the version token. Without a
+    cache, return a fresh token so the runner performs the full live read
+    rather than silently skipping a mutable upstream.
+    """
+    paths = tuple(cache_paths)
+
+    def _version() -> str:
+        existing = [
+            (raw, resolve_repo_path(raw, base=base))
+            for raw in paths
+            if resolve_repo_path(raw, base=base).is_file()
+        ]
+        if not existing:
+            return datetime.now(timezone.utc).isoformat()
+        digest = hashlib.sha256()
+        for raw, path in sorted(existing, key=lambda item: str(item[0])):
+            digest.update(str(raw).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    return MutableApiProbe(
+        version_fn=_version,
+        config=config,
+        emit_targets=emit_targets,
+    )

--- a/python/archi/auth/cookies.py
+++ b/python/archi/auth/cookies.py
@@ -1,0 +1,157 @@
+"""CERN SSO cookie-file helpers.
+
+Rewritten from okg-deployments ``cms/cms_sources/preflight.py`` (cookie
+loading, login-page detection) and ``cms/scripts/sso-login.py`` (cookie
+save/verify flow) at ``main@f33a9c4``, plus archi
+``dev@28b977d1:src/data_manager/collectors/scrapers/auth/`` (login-page
+URL patterns and credential-freshness semantics from the Scrapy
+``AuthProvider`` layer). Changes: the dev branch's Playwright login
+provider and Scrapy middleware plumbing are not ported — v3 never runs
+an interactive login in-process; the freshness/TTL idea from dev's
+``Credentials`` object becomes :func:`check_cookie_file`.
+
+Acquisition (documented, not executed here)
+-------------------------------------------
+Cookie files are Netscape/Mozilla format, produced out-of-band:
+
+- CERN's official ``auth-get-sso-cookie`` tool (Kerberos-backed,
+  available on lxplus)::
+
+      kinit <user>@CERN.CH
+      auth-get-sso-cookie -u <protected-url> -o <cookie-file>
+
+- or the interactive Kerberos+TOTP flow in
+  ``okg-deployments/cms/scripts/sso-login.py``, which drives CERN
+  Keycloak once per session and saves per-service cookie files.
+
+Modules here only ever *read* cookie files; the file paths arrive via
+environment-variable references, never as embedded values.
+"""
+from __future__ import annotations
+
+import http.cookiejar
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+LOGIN_URL_PATTERNS: tuple[str, ...] = (
+    r"auth\.cern\.ch",
+    r"login\.cern\.ch",
+    r"/login",
+    r"/sso/",
+    r"keycloak",
+)
+_LOGIN_URL_RE = re.compile("|".join(LOGIN_URL_PATTERNS), re.IGNORECASE)
+_LOGIN_TEXT_MARKERS: tuple[str, ...] = (
+    "sign in to cern",
+    "auth.cern.ch",
+    "login.cern.ch",
+)
+
+
+def looks_like_login_url(url: str) -> bool:
+    """Return True if *url* matches known CERN SSO login-page patterns."""
+    return bool(_LOGIN_URL_RE.search(url))
+
+
+def looks_like_login_page(text: str) -> bool:
+    """Return True if *text* (URL or page body) reads as a CERN login page."""
+    lowered = text.lower()
+    return any(marker in lowered for marker in _LOGIN_TEXT_MARKERS)
+
+
+def sso_cookie_acquisition_command(url: str, cookie_file: str | Path) -> str:
+    """The documented out-of-band command that produces *cookie_file*."""
+    return f"auth-get-sso-cookie -u {url} -o {cookie_file}"
+
+
+def load_cookie_jar(path: str | Path) -> http.cookiejar.MozillaCookieJar:
+    """Load a Netscape/Mozilla cookie file, keeping expired/session cookies."""
+    jar = http.cookiejar.MozillaCookieJar(str(Path(path).expanduser()))
+    jar.load(ignore_discard=True, ignore_expires=True)
+    return jar
+
+
+@dataclass(frozen=True)
+class CookieFileStatus:
+    """Offline freshness verdict for one cookie file."""
+
+    path: Path
+    exists: bool
+    cookie_count: int = 0
+    live_count: int = 0
+    expired_count: int = 0
+    session_count: int = 0
+    earliest_expiry: datetime | None = None
+    age: timedelta | None = None
+    fresh: bool = False
+    reason: str = ""
+
+
+def check_cookie_file(
+    path: str | Path,
+    *,
+    domain: str | None = None,
+    max_age: timedelta | None = None,
+    now: datetime | None = None,
+) -> CookieFileStatus:
+    """Validate a cookie file without any network traffic.
+
+    Fresh means: at least one unexpired (or session) cookie, optionally
+    scoped to *domain*, and the file itself is no older than *max_age*.
+    """
+    p = Path(path).expanduser()
+    moment = now or datetime.now(timezone.utc)
+    if not p.is_file():
+        return CookieFileStatus(
+            path=p, exists=False, reason="cookie file is missing",
+        )
+    try:
+        jar = load_cookie_jar(p)
+    except Exception as exc:  # noqa: BLE001
+        return CookieFileStatus(
+            path=p,
+            exists=True,
+            reason=f"cookie file could not be parsed: {type(exc).__name__}",
+        )
+    cookies = [
+        c for c in jar
+        if domain is None or c.domain.endswith(domain)
+    ]
+    session_count = sum(1 for c in cookies if c.expires is None)
+    expiries = [
+        datetime.fromtimestamp(c.expires, tz=timezone.utc)
+        for c in cookies
+        if c.expires is not None
+    ]
+    expired_count = sum(1 for e in expiries if e <= moment)
+    live_expiries = sorted(e for e in expiries if e > moment)
+    live_count = session_count + len(live_expiries)
+    age = moment - datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc)
+    earliest = live_expiries[0] if live_expiries else None
+    if not cookies:
+        scope = f" for domain {domain}" if domain else ""
+        fresh, reason = False, f"cookie file has no cookies{scope}"
+    elif live_count == 0:
+        fresh, reason = False, f"all {len(cookies)} cookies are expired"
+    elif max_age is not None and age > max_age:
+        fresh, reason = False, (
+            f"cookie file is older than max age "
+            f"({age.total_seconds() / 3600:.1f}h > "
+            f"{max_age.total_seconds() / 3600:.1f}h)"
+        )
+    else:
+        fresh, reason = True, f"{live_count} live cookies"
+    return CookieFileStatus(
+        path=p,
+        exists=True,
+        cookie_count=len(cookies),
+        live_count=live_count,
+        expired_count=expired_count,
+        session_count=session_count,
+        earliest_expiry=earliest,
+        age=age,
+        fresh=fresh,
+        reason=reason,
+    )

--- a/python/archi/auth/preflight.py
+++ b/python/archi/auth/preflight.py
@@ -343,11 +343,22 @@ class CERNPreflightSource:
                 ),
                 checked_at=_checked_at(),
             )
-        reason = (
-            f"X.509 proxy valid until {expiry.isoformat()}"
-            if expiry is not None
-            else "X.509 proxy file present; expiry could not be read"
-        )
+        if expiry is None:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="auth_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=result.alias_refs,
+                reason=(
+                    "X.509 proxy file present but its certificate could not "
+                    "be decoded; re-create the proxy (this offline kind has "
+                    "no live-probe backstop, so an unreadable proxy must not "
+                    "pass as healthy)"
+                ),
+                checked_at=_checked_at(),
+            )
         return SourcePreflightResult(
             source_name=self.name,
             status="ok",
@@ -355,7 +366,7 @@ class CERNPreflightSource:
             required=self.required,
             credential_refs=(self._credential_ref(),),
             alias_refs=result.alias_refs,
-            reason=reason,
+            reason=f"X.509 proxy valid until {expiry.isoformat()}",
             checked_at=_checked_at(),
         )
 
@@ -373,10 +384,27 @@ class CERNPreflightSource:
         cookie_path = _credential_file_path(
             self._credential_ref(), self.aliases,
         )
-        try:
-            session = requests.Session()
-            if cookie_path is not None:
+        session = requests.Session()
+        if cookie_path is not None:
+            try:
                 _load_cookie_file(session, cookie_path)
+            except Exception as exc:  # noqa: BLE001
+                return SourcePreflightResult(
+                    source_name=self.name,
+                    status="auth_failed",
+                    mode=mode,
+                    required=self.required,
+                    credential_refs=(self._credential_ref(),),
+                    alias_refs=file_result.alias_refs,
+                    endpoint=endpoint,
+                    reason=redact_text(
+                        f"SSO cookie file could not be parsed — re-acquire "
+                        f"it (no request was sent): "
+                        f"{type(exc).__name__}: {exc}"
+                    ),
+                    checked_at=_checked_at(),
+                )
+        try:
             response = session.get(
                 endpoint,
                 timeout=self.timeout,

--- a/python/archi/auth/preflight.py
+++ b/python/archi/auth/preflight.py
@@ -1,0 +1,718 @@
+"""CERN credential/reachability preflight source.
+
+Rewritten from okg-deployments ``cms/cms_sources/preflight.py``
+(``CMSPreflightSource``, 674 LOC) at ``main@f33a9c4``. Changes:
+
+- De-CMS-ified: ``CERNPreflightSource``; the CMS default endpoints are
+  gone — HTTP kinds require an explicit ``endpoint`` param, so the CMS
+  probe set stays expressible via registry params.
+- The ``jira`` live-probe kind is dropped; the live JIRA check belongs
+  with the jira source port, and token presence stays expressible via
+  kind ``token``.
+- New offline kinds ``sso_cookie`` (cookie-file freshness/expiry via
+  :mod:`archi.auth.cookies`) and ``x509_proxy`` (proxy presence +
+  expiry, extracted from the original ``x509_http`` pre-check), plus a
+  credential-free ``https`` reachability kind.
+- ``run()`` reports health from a live-mode preflight (the original
+  tagged it ``cache``).
+
+Probes emit no NodeFact/EdgeFact; a run returns an empty fact stream
+with a SourceHealth summarizing the probe outcome. The failure
+vocabulary is unchanged: ``ok`` / ``missing_credential`` /
+``auth_failed`` / ``tls_failed`` / ``endpoint_failed`` /
+``cache_missing``. Credentials arrive as env-var references and file
+paths only; no values are read into results.
+"""
+from __future__ import annotations
+
+import json
+import os
+import ssl
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+import requests
+
+from okg.substrate.library.sources.base import (
+    SourcePreflightResult,
+    SourceRun,
+)
+from okg.substrate.sources.preflight import (
+    credential_env_preflight,
+    file_ref_preflight,
+    http_probe_result,
+)
+from okg.substrate.sources.redaction import redact_text
+
+from archi.auth.cache import resolve_repo_path
+from archi.auth.cookies import (
+    check_cookie_file,
+    load_cookie_jar,
+    looks_like_login_page,
+    looks_like_login_url,
+)
+
+
+def _checked_at() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _env(env: Mapping[str, str] | None = None) -> Mapping[str, str]:
+    return os.environ if env is None else env
+
+
+def _json_record_count(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, dict):
+        for key in ("records", "items", "results", "data"):
+            inner = value.get(key)
+            if isinstance(inner, list):
+                return len(inner)
+        list_values = [v for v in value.values() if isinstance(v, list)]
+        if list_values:
+            return sum(len(v) for v in list_values)
+        return 1 if value else 0
+    return 1
+
+
+def _credential_file_path(
+    credential_ref: str,
+    aliases: tuple[str, ...],
+) -> Path | None:
+    env = _env()
+    for ref in (credential_ref,) + aliases:
+        value = env.get(ref)
+        if value and Path(value).expanduser().is_file():
+            return Path(value).expanduser()
+    return None
+
+
+def _load_cookie_file(session: requests.Session, path: Path) -> None:
+    session.cookies.update(load_cookie_jar(path))
+
+
+def _with_credential_context(
+    result: SourcePreflightResult,
+    *,
+    credential_ref: str,
+    alias_refs: Mapping[str, tuple[str, ...]],
+) -> SourcePreflightResult:
+    data = result.as_dict()
+    data["credential_refs"] = (credential_ref,)
+    data["alias_refs"] = dict(alias_refs)
+    return SourcePreflightResult(**data)
+
+
+def _login_page_detected(url: str, text: str) -> bool:
+    return looks_like_login_url(url) or looks_like_login_page(text[:2000])
+
+
+class CERNPreflightSource:
+    """Registry-instantiable credential/reachability preflight adapter.
+
+    One instance covers one probe; the probe list is name/params-driven
+    from the source registry (``kind`` selects the check, everything
+    else arrives as params). Emits no graph facts.
+    """
+
+    profile = "live_overlay"
+
+    def __init__(
+        self,
+        *,
+        source_name: str,
+        kind: str,
+        required: bool = False,
+        credential_ref: str | None = None,
+        aliases: list[str] | None = None,
+        cache_paths: list[str] | None = None,
+        credential_refs: list[str] | None = None,
+        endpoint: str | None = None,
+        timeout: float = 10.0,
+        max_age_hours: float | None = None,
+        base: str | None = None,
+    ) -> None:
+        self.name = source_name
+        self.kind = kind
+        self.required = required
+        self.credential_ref = credential_ref
+        self.aliases = tuple(aliases or ())
+        self.cache_paths = tuple(cache_paths or ())
+        self.credential_refs = tuple(credential_refs or ())
+        self.endpoint = endpoint
+        self.timeout = float(timeout)
+        self.max_age_hours = (
+            float(max_age_hours) if max_age_hours is not None else None
+        )
+        self.base = base
+
+    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+        if self.kind == "cache":
+            return self._cache_preflight(mode=mode)
+        if self.kind == "token":
+            return credential_env_preflight(
+                self.name,
+                self._credential_ref(),
+                aliases=self.aliases,
+                required=self.required,
+                mode=mode,
+            )
+        if self.kind == "file":
+            return file_ref_preflight(
+                self.name,
+                self._credential_ref(),
+                aliases=self.aliases,
+                required=self.required,
+                mode=mode,
+            )
+        if self.kind == "ca_bundle":
+            return self._ca_bundle_preflight(mode=mode)
+        if self.kind == "sso_cookie":
+            return self._sso_cookie_preflight(mode=mode)
+        if self.kind == "x509_proxy":
+            return self._x509_proxy_preflight(mode=mode)
+        if self.kind == "cern_sso_http":
+            return self._cern_sso_http_preflight(mode=mode)
+        if self.kind == "cern_tls":
+            return self._cern_tls_preflight(mode=mode)
+        if self.kind == "x509_http":
+            return self._x509_http_preflight(mode=mode)
+        if self.kind == "https":
+            return self._https_preflight(mode=mode)
+        if self.kind == "any_file":
+            return self._any_file_preflight(mode=mode)
+        if self.kind == "all_env":
+            return self._all_env_preflight(mode=mode)
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="endpoint_failed",
+            mode=mode,
+            required=self.required,
+            reason=f"unknown preflight kind {self.kind!r}",
+            checked_at=_checked_at(),
+        )
+
+    def run(
+        self,
+        run_id: str,
+        *,
+        mode: str = "cursor",
+        sync_scope: Optional[Mapping[str, Any]] = None,
+    ) -> SourceRun:
+        return SourceRun(facts=[], health=self.preflight())
+
+    def _credential_ref(self) -> str:
+        if not self.credential_ref:
+            raise ValueError(
+                f"{self.name}: credential_ref is required for {self.kind}"
+            )
+        return self.credential_ref
+
+    def _endpoint(self) -> str:
+        if not self.endpoint:
+            raise ValueError(
+                f"{self.name}: endpoint is required for {self.kind}"
+            )
+        return self.endpoint
+
+    def _cache_preflight(self, *, mode: str) -> SourcePreflightResult:
+        paths = [
+            resolve_repo_path(p, base=self.base) for p in self.cache_paths
+        ]
+        missing = [p for p in paths if not p.exists()]
+        if missing:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="cache_missing",
+                mode="cache",
+                required=self.required,
+                cache_path=", ".join(str(p) for p in missing),
+                reason="one or more expected cache files are missing",
+                checked_at=_checked_at(),
+            )
+        count = 0
+        for path in paths:
+            try:
+                count += _json_record_count(path)
+            except Exception as exc:  # noqa: BLE001
+                return SourcePreflightResult(
+                    source_name=self.name,
+                    status="cache_missing",
+                    mode="cache",
+                    required=self.required,
+                    cache_path=str(path),
+                    reason=(
+                        f"failed to read cache: {type(exc).__name__}: {exc}"
+                    ),
+                    checked_at=_checked_at(),
+                )
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="ok",
+            mode="cache",
+            required=self.required,
+            record_count=count,
+            reason="local cache present",
+            checked_at=_checked_at(),
+        )
+
+    def _ca_bundle_preflight(self, *, mode: str) -> SourcePreflightResult:
+        result = file_ref_preflight(
+            self.name,
+            self._credential_ref(),
+            aliases=self.aliases,
+            required=self.required,
+            mode=mode,
+        )
+        if result.status != "ok":
+            data = result.as_dict()
+            data["status"] = "tls_failed"
+            data["reason"] = "CERN CA bundle is missing; refusing TLS bypass"
+            return SourcePreflightResult(**data)
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="ok",
+            mode=mode,
+            required=self.required,
+            credential_refs=(self._credential_ref(),),
+            alias_refs=result.alias_refs,
+            reason="CERN CA bundle present",
+            checked_at=_checked_at(),
+        )
+
+    def _sso_cookie_preflight(self, *, mode: str) -> SourcePreflightResult:
+        result = file_ref_preflight(
+            self.name,
+            self._credential_ref(),
+            aliases=self.aliases,
+            required=self.required,
+            mode=mode,
+        )
+        if result.status != "ok":
+            return result
+        cookie_path = _credential_file_path(
+            self._credential_ref(), self.aliases,
+        )
+        max_age = (
+            timedelta(hours=self.max_age_hours)
+            if self.max_age_hours is not None else None
+        )
+        status = check_cookie_file(cookie_path, max_age=max_age)
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="ok" if status.fresh else "auth_failed",
+            mode=mode,
+            required=self.required,
+            credential_refs=(self._credential_ref(),),
+            alias_refs=result.alias_refs,
+            reason=f"SSO cookie file: {status.reason}",
+            checked_at=_checked_at(),
+        )
+
+    def _x509_proxy_preflight(self, *, mode: str) -> SourcePreflightResult:
+        result = file_ref_preflight(
+            self.name,
+            self._credential_ref(),
+            aliases=self.aliases,
+            required=self.required,
+            mode=mode,
+        )
+        if result.status != "ok":
+            return result
+        proxy_path = _credential_file_path(
+            self._credential_ref(), self.aliases,
+        )
+        expiry = _x509_not_after(proxy_path)
+        if expiry is not None and expiry <= datetime.now(timezone.utc):
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="auth_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=result.alias_refs,
+                reason=(
+                    f"{self._credential_ref()} expired at {expiry.isoformat()}"
+                ),
+                checked_at=_checked_at(),
+            )
+        reason = (
+            f"X.509 proxy valid until {expiry.isoformat()}"
+            if expiry is not None
+            else "X.509 proxy file present; expiry could not be read"
+        )
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="ok",
+            mode=mode,
+            required=self.required,
+            credential_refs=(self._credential_ref(),),
+            alias_refs=result.alias_refs,
+            reason=reason,
+            checked_at=_checked_at(),
+        )
+
+    def _cern_sso_http_preflight(self, *, mode: str) -> SourcePreflightResult:
+        endpoint = self._endpoint()
+        file_result = file_ref_preflight(
+            self.name,
+            self._credential_ref(),
+            aliases=self.aliases,
+            required=self.required,
+            mode=mode,
+        )
+        if file_result.status != "ok":
+            return file_result
+        cookie_path = _credential_file_path(
+            self._credential_ref(), self.aliases,
+        )
+        try:
+            session = requests.Session()
+            if cookie_path is not None:
+                _load_cookie_file(session, cookie_path)
+            response = session.get(
+                endpoint,
+                timeout=self.timeout,
+                allow_redirects=True,
+            )
+        except requests.exceptions.SSLError as exc:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="tls_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=file_result.alias_refs,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"CERN SSO HTTP probe failed TLS: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=file_result.alias_refs,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"CERN SSO HTTP probe failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        text = getattr(response, "text", "") or ""
+        url = getattr(response, "url", endpoint) or endpoint
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        login_page = _login_page_detected(url, text)
+        if status_code == 200 and login_page:
+            reason = "CERN SSO cookie reached login page"
+        elif status_code == 200:
+            reason = "CERN SSO HTTP probe returned authenticated payload"
+        else:
+            reason = f"CERN SSO HTTP probe returned HTTP {status_code}"
+        return _with_credential_context(
+            http_probe_result(
+                self.name,
+                ok=status_code == 200,
+                endpoint=endpoint,
+                required=self.required,
+                mode=mode,
+                reason=reason,
+                login_page_detected=login_page or status_code in {401, 403},
+            ),
+            credential_ref=self._credential_ref(),
+            alias_refs=file_result.alias_refs,
+        )
+
+    def _cern_tls_preflight(self, *, mode: str) -> SourcePreflightResult:
+        endpoint = self._endpoint()
+        ca_result = self._ca_bundle_preflight(mode=mode)
+        if ca_result.status != "ok":
+            return ca_result
+        ca_path = _credential_file_path(self._credential_ref(), self.aliases)
+        try:
+            response = requests.Session().get(
+                endpoint,
+                timeout=self.timeout,
+                allow_redirects=True,
+                verify=str(ca_path),
+            )
+        except requests.exceptions.SSLError as exc:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="tls_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=ca_result.alias_refs,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"CERN TLS probe failed: {type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=(self._credential_ref(),),
+                alias_refs=ca_result.alias_refs,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"CERN TLS probe failed: {type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        text = getattr(response, "text", "") or ""
+        url = getattr(response, "url", endpoint) or endpoint
+        login_page = _login_page_detected(url, text)
+        if status_code == 200 and login_page:
+            reason = "CERN TLS probe reached login page"
+        elif status_code == 200:
+            reason = "CERN TLS probe succeeded with configured CA bundle"
+        else:
+            reason = f"CERN TLS probe returned HTTP {status_code}"
+        return _with_credential_context(
+            http_probe_result(
+                self.name,
+                ok=status_code == 200,
+                endpoint=endpoint,
+                required=self.required,
+                mode=mode,
+                reason=reason,
+                login_page_detected=login_page or status_code in {401, 403},
+            ),
+            credential_ref=self._credential_ref(),
+            alias_refs=ca_result.alias_refs,
+        )
+
+    def _x509_http_preflight(self, *, mode: str) -> SourcePreflightResult:
+        endpoint = self._endpoint()
+        refs = self.credential_refs or (self._credential_ref(),)
+        proxy_ref = refs[0]
+        ca_ref = refs[1] if len(refs) > 1 else None
+        proxy_result = file_ref_preflight(
+            self.name,
+            proxy_ref,
+            required=self.required,
+            mode=mode,
+        )
+        if proxy_result.status != "ok":
+            return proxy_result
+        proxy_path = _credential_file_path(proxy_ref, ())
+        if proxy_path is None:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="missing_credential",
+                mode=mode,
+                required=self.required,
+                credential_refs=tuple(refs),
+                reason=f"{proxy_ref} file is not set or does not exist",
+                checked_at=_checked_at(),
+            )
+        expiry = _x509_not_after(proxy_path)
+        if expiry is not None and expiry <= datetime.now(timezone.utc):
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="auth_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=tuple(refs),
+                endpoint=endpoint,
+                reason=f"{proxy_ref} expired at {expiry.isoformat()}",
+                checked_at=_checked_at(),
+            )
+        ca_path: Path | None = None
+        if ca_ref:
+            ca_result = file_ref_preflight(
+                self.name,
+                ca_ref,
+                required=self.required,
+                mode=mode,
+            )
+            if ca_result.status != "ok":
+                data = ca_result.as_dict()
+                data["credential_refs"] = tuple(refs)
+                data["status"] = "tls_failed"
+                return SourcePreflightResult(**data)
+            ca_path = _credential_file_path(ca_ref, ())
+        try:
+            response = requests.Session().get(
+                endpoint,
+                timeout=self.timeout,
+                allow_redirects=True,
+                cert=str(proxy_path),
+                verify=str(ca_path) if ca_path is not None else True,
+            )
+        except requests.exceptions.SSLError as exc:
+            text = str(exc)
+            return SourcePreflightResult(
+                source_name=self.name,
+                status=(
+                    "auth_failed"
+                    if "bad certificate" in text.lower() else "tls_failed"
+                ),
+                mode=mode,
+                required=self.required,
+                credential_refs=tuple(refs),
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"X.509 HTTPS probe failed TLS: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode=mode,
+                required=self.required,
+                credential_refs=tuple(refs),
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"X.509 HTTPS probe failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        return _with_credential_context(
+            http_probe_result(
+                self.name,
+                ok=status_code == 200,
+                endpoint=endpoint,
+                required=self.required,
+                mode=mode,
+                reason=f"X.509 HTTPS probe returned HTTP {status_code}",
+                login_page_detected=status_code in {401, 403},
+            ),
+            credential_ref=proxy_ref,
+            alias_refs={},
+        )
+
+    def _https_preflight(self, *, mode: str) -> SourcePreflightResult:
+        endpoint = self._endpoint()
+        try:
+            response = requests.Session().get(
+                endpoint,
+                timeout=self.timeout,
+                allow_redirects=True,
+            )
+        except requests.exceptions.SSLError as exc:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="tls_failed",
+                mode=mode,
+                required=self.required,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"HTTPS probe failed TLS: {type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode=mode,
+                required=self.required,
+                endpoint=endpoint,
+                reason=redact_text(
+                    f"HTTPS probe failed: {type(exc).__name__}: {exc}"
+                ),
+                checked_at=_checked_at(),
+            )
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        text = getattr(response, "text", "") or ""
+        url = getattr(response, "url", endpoint) or endpoint
+        login_page = _login_page_detected(url, text)
+        return http_probe_result(
+            self.name,
+            ok=status_code == 200,
+            endpoint=endpoint,
+            required=self.required,
+            mode=mode,
+            reason=f"HTTPS probe returned HTTP {status_code}",
+            login_page_detected=login_page or status_code in {401, 403},
+        )
+
+    def _any_file_preflight(self, *, mode: str) -> SourcePreflightResult:
+        refs = self.credential_refs or (self._credential_ref(),)
+        env = _env()
+        for ref in refs:
+            value = env.get(ref)
+            if value and Path(value).expanduser().is_file():
+                return SourcePreflightResult(
+                    source_name=self.name,
+                    status="ok",
+                    mode=mode,
+                    required=self.required,
+                    credential_refs=tuple(refs),
+                    reason=f"{ref} file exists",
+                    checked_at=_checked_at(),
+                )
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="missing_credential",
+            mode=mode,
+            required=self.required,
+            credential_refs=tuple(refs),
+            reason="no acceptable credential file is set",
+            checked_at=_checked_at(),
+        )
+
+    def _all_env_preflight(self, *, mode: str) -> SourcePreflightResult:
+        refs = self.credential_refs or (self._credential_ref(),)
+        env = _env()
+        missing = [ref for ref in refs if not env.get(ref)]
+        if missing:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="missing_credential",
+                mode=mode,
+                required=self.required,
+                credential_refs=tuple(refs),
+                reason="missing env refs: " + ", ".join(missing),
+                checked_at=_checked_at(),
+            )
+        return SourcePreflightResult(
+            source_name=self.name,
+            status="ok",
+            mode=mode,
+            required=self.required,
+            credential_refs=tuple(refs),
+            reason="all required env refs are set",
+            checked_at=_checked_at(),
+        )
+
+
+def _x509_not_after(path: Path | None) -> datetime | None:
+    if path is None:
+        return None
+    try:
+        info = ssl._ssl._test_decode_cert(str(path))  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        return None
+    raw = info.get("notAfter")
+    if not raw:
+        return None
+    parsed = parsedate_to_datetime(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/python/archi/schemas/operations_w1.yaml
+++ b/python/archi/schemas/operations_w1.yaml
@@ -1,0 +1,41 @@
+# Archi W1 — deployment-scoped schema slice (seam proof).
+# One subtype, mirrored from the proven CMS deployment schema shape.
+id: https://archi-physics.org/okg/archi/w1
+name: archi_w1_operations
+title: Archi W1 — CMSSW release subtype
+description: Deployment-scoped slice of the Archi operations schema.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  archi: https://archi-physics.org/okg/archi/
+
+default_range: string
+
+imports:
+  - linkml:types
+
+classes:
+
+  CMSSWRelease:
+    description: CMS software framework release.
+    class_uri: archi:CMSSWRelease
+    attributes:
+      release:
+        required: true
+      release_type:
+      state:
+      architecture:
+      release_date:
+      major:
+        range: integer
+      minor:
+        range: integer
+      patch:
+        range: integer
+      suffix:
+      text:
+    annotations:
+      archetype: artifact
+      transient: "false"
+      okg_alias_fields: release
+      okg_searchable_text_fields: release,release_type,architecture,text

--- a/python/archi/sources/cmssw.py
+++ b/python/archi/sources/cmssw.py
@@ -1,0 +1,149 @@
+"""CMSSW release catalog source — W1 seam proof.
+
+Fetches the public cms-bot ``releases.map`` (no auth) into a local
+cache, then emits one ``cmssw_release`` node per release label.
+Mirrors the proven adapter idiom from okg-deployments/cms (cache file
++ content-hash probe), with the fetch folded into the adapter so W1
+proves a real network read. W2 note: a periodically-refreshed remote
+catalog wants a mutable_api probe — the content-hash probe here only
+sees the cache, so it cannot detect upstream change on its own.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional
+
+from okg.substrate.library.sources.base import (
+    NodeFact,
+    SourceHealth,
+    SourceRun,
+)
+from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
+
+RELEASES_MAP_URL = (
+    "https://raw.githubusercontent.com/cms-sw/cms-bot/master/releases.map"
+)
+_VERSION_RE = re.compile(r"^CMSSW_(\d+)_(\d+)_(\d+)(?:_(.+))?$")
+
+
+def _parse_releases(raw: str, limit: int) -> list[dict[str, Any]]:
+    by_label: dict[str, dict[str, Any]] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        fields = dict(
+            part.split("=", 1) for part in line.split(";") if "=" in part
+        )
+        label = fields.get("label", "")
+        m = _VERSION_RE.match(label)
+        if not m:
+            continue
+        rec = by_label.setdefault(
+            label,
+            {
+                "release": label,
+                "release_type": fields.get("type", ""),
+                "state": fields.get("state", ""),
+                "architecture": [],
+                "major": int(m.group(1)),
+                "minor": int(m.group(2)),
+                "patch": int(m.group(3)),
+                "suffix": m.group(4) or "",
+                "text": f"{label} {fields.get('type', '')} {fields.get('state', '')}".strip(),
+            },
+        )
+        arch = fields.get("architecture", "")
+        if arch and arch not in rec["architecture"]:
+            rec["architecture"].append(arch)
+    records = sorted(
+        by_label.values(),
+        key=lambda r: (r["major"], r["minor"], r["patch"], r["release"]),
+    )
+    for rec in records:
+        rec["architecture"] = sorted(rec["architecture"])
+    if limit > 0:
+        records = records[-limit:]
+    return records
+
+
+class CMSSWReleaseSource:
+    """Public CMSSW release catalog (cms-bot releases.map)."""
+
+    name = "cmssw_releases"
+    profile = "reference_catalog"
+    change_probe_kind = "content_hash"
+
+    def __init__(
+        self,
+        *,
+        cache_path: str,
+        url: str = RELEASES_MAP_URL,
+        limit: int = 300,
+        fetch: bool = True,
+    ) -> None:
+        self.cache_path = Path(cache_path)
+        self.url = url
+        self.limit = int(limit)
+        self.fetch = bool(fetch)
+        self.change_probe = ContentHashProbe(
+            content_items=self._probe_items,
+            config={
+                "cache_path": str(cache_path),
+                "url": url,
+                "limit": self.limit,
+            },
+            emit_targets=CMSSWReleaseSource,
+        )
+
+    def _probe_items(self) -> list[tuple[str, Path]]:
+        if self.cache_path.is_file():
+            return [(str(self.cache_path), self.cache_path)]
+        return []
+
+    def _download(self) -> None:
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with urllib.request.urlopen(self.url, timeout=60) as resp:
+            self.cache_path.write_bytes(resp.read())
+
+    def run(
+        self,
+        run_id: str,
+        *,
+        mode: str = "cursor",
+        sync_scope: Optional[Mapping[str, Any]] = None,
+    ) -> SourceRun:
+        if self.fetch or not self.cache_path.is_file():
+            self._download()
+        raw = self.cache_path.read_text(encoding="utf-8", errors="replace")
+        records = _parse_releases(raw, self.limit)
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+        def _facts() -> Iterator[NodeFact]:
+            for rec in records:
+                yield NodeFact(
+                    node_id=f"cmssw_release:{rec['release']}",
+                    subtype="cmssw_release",
+                    attrs=rec,
+                    source_record_id={"release": rec["release"]},
+                    source_revision={
+                        "content_hash": digest,
+                        "run_id": run_id,
+                    },
+                )
+
+        return SourceRun(
+            facts=_facts(),
+            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            run_mode=mode,
+            health=SourceHealth(
+                status="ok",
+                mode="live",
+                record_count=len(records),
+                content_hash=digest,
+                reason="releases.map fetched from cms-bot",
+            ),
+        )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "archi"
+version = "3.0.0a1"
+description = "Archi — the HEP distribution of OKG (v3 distribution)"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.hatch.build.targets.wheel]
+packages = ["archi"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,9 @@ name = "archi"
 version = "3.0.0a1"
 description = "Archi — the HEP distribution of OKG (v3 distribution)"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "requests>=2.31",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["archi"]

--- a/python/tests/auth/test_cache.py
+++ b/python/tests/auth/test_cache.py
@@ -1,0 +1,106 @@
+"""req.w2.auth — cache resolve/hash/probe behavior, offline."""
+import json
+import time
+from pathlib import Path
+
+from archi.auth import cache
+
+
+def test_resolve_absolute_path_passes_through(tmp_path):
+    target = tmp_path / "x.json"
+    assert cache.resolve_repo_path(target) == target
+
+
+def test_resolve_with_explicit_base(tmp_path):
+    resolved = cache.resolve_repo_path("data/a.json", base=tmp_path)
+    assert resolved == tmp_path / "data" / "a.json"
+
+
+def test_resolve_env_data_root(tmp_path, monkeypatch):
+    monkeypatch.setenv(cache.DATA_ROOT_ENV, str(tmp_path))
+    assert cache.resolve_repo_path("a.json") == tmp_path / "a.json"
+
+
+def test_explicit_base_wins_over_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(cache.DATA_ROOT_ENV, str(tmp_path / "env"))
+    resolved = cache.resolve_repo_path("a.json", base=tmp_path / "param")
+    assert resolved == tmp_path / "param" / "a.json"
+
+
+def test_resolve_falls_back_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.delenv(cache.DATA_ROOT_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert cache.resolve_repo_path("a.json") == tmp_path / "a.json"
+
+
+def test_load_json(tmp_path):
+    (tmp_path / "a.json").write_text(json.dumps({"k": [1, 2]}))
+    assert cache.load_json("a.json", base=tmp_path) == {"k": [1, 2]}
+
+
+def test_content_hash_stable_and_order_insensitive(tmp_path):
+    (tmp_path / "a.json").write_text("[1]")
+    (tmp_path / "b.json").write_text("[2]")
+    h1 = cache.content_hash(["a.json", "b.json"], base=tmp_path)
+    h2 = cache.content_hash(["b.json", "a.json"], base=tmp_path)
+    assert h1 == h2
+    assert len(h1) == 64
+
+
+def test_content_hash_changes_with_content(tmp_path):
+    path = tmp_path / "a.json"
+    path.write_text("[1]")
+    before = cache.content_hash(["a.json"], base=tmp_path)
+    path.write_text("[1, 2]")
+    assert cache.content_hash(["a.json"], base=tmp_path) != before
+
+
+def test_content_hash_is_label_sensitive(tmp_path):
+    (tmp_path / "a.json").write_text("[1]")
+    (tmp_path / "b.json").write_text("[1]")
+    assert cache.content_hash(["a.json"], base=tmp_path) != cache.content_hash(
+        ["b.json"], base=tmp_path
+    )
+
+
+def test_content_hash_change_probe_tracks_file_content(tmp_path):
+    path = tmp_path / "a.json"
+    path.write_text("[1]")
+    probe = cache.content_hash_change_probe(
+        cache_paths=["a.json", "missing.json"],
+        config={"cache_path": "a.json"},
+        emit_targets=test_content_hash_change_probe_tracks_file_content,
+        base=tmp_path,
+    )
+    before = probe.build_token()
+    assert probe.build_token() == before
+    path.write_text("[1, 2]")
+    assert probe.build_token() != before
+
+
+def test_forced_live_probe_without_cache_always_advances(tmp_path):
+    probe = cache.cache_or_forced_live_change_probe(
+        cache_paths=["missing.json"],
+        config={},
+        emit_targets=test_forced_live_probe_without_cache_always_advances,
+        base=tmp_path,
+    )
+    first = probe.build_token()
+    time.sleep(0.002)
+    assert probe.build_token() != first
+
+
+def test_forced_live_probe_with_cache_uses_content_hash(tmp_path):
+    path = tmp_path / "a.json"
+    path.write_text("[1]")
+    probe = cache.cache_or_forced_live_change_probe(
+        cache_paths=["a.json"],
+        config={},
+        emit_targets=test_forced_live_probe_with_cache_uses_content_hash,
+        base=tmp_path,
+    )
+    first = probe.build_token()
+    time.sleep(0.002)
+    assert probe.build_token() == first
+    path.write_text("[2]")
+    assert probe.build_token() != first

--- a/python/tests/auth/test_cookies.py
+++ b/python/tests/auth/test_cookies.py
@@ -1,0 +1,122 @@
+"""req.w2.auth — cookie-file parse/expiry helpers, offline."""
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from archi.auth import cookies
+
+_FAR_FUTURE = int(datetime(2035, 1, 1, tzinfo=timezone.utc).timestamp())
+_PAST = int(datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp())
+
+
+def _write_cookie_file(path: Path, rows: list[tuple[str, str, int | str]]):
+    lines = ["# Netscape HTTP Cookie File"]
+    for domain, name, expires in rows:
+        lines.append(
+            f"{domain}\tTRUE\t/\tTRUE\t{expires}\t{name}\ttest-value"
+        )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_load_cookie_jar_keeps_expired_cookies(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(
+        path,
+        [(".cern.ch", "live", _FAR_FUTURE), (".cern.ch", "dead", _PAST)],
+    )
+    jar = cookies.load_cookie_jar(path)
+    assert sorted(c.name for c in jar) == ["dead", "live"]
+
+
+def test_check_missing_file(tmp_path):
+    status = cookies.check_cookie_file(tmp_path / "absent.txt")
+    assert not status.exists
+    assert not status.fresh
+    assert "missing" in status.reason
+
+
+def test_check_unparseable_file(tmp_path):
+    path = tmp_path / "c.txt"
+    path.write_text("this is not a cookie file\n")
+    status = cookies.check_cookie_file(path)
+    assert status.exists
+    assert not status.fresh
+    assert "could not be parsed" in status.reason
+
+
+def test_check_fresh_cookie_file(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(
+        path,
+        [(".cern.ch", "live", _FAR_FUTURE), (".cern.ch", "dead", _PAST)],
+    )
+    status = cookies.check_cookie_file(path)
+    assert status.fresh
+    assert status.cookie_count == 2
+    assert status.live_count == 1
+    assert status.expired_count == 1
+    assert status.earliest_expiry == datetime.fromtimestamp(
+        _FAR_FUTURE, tz=timezone.utc
+    )
+
+
+def test_check_all_expired(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(path, [(".cern.ch", "dead", _PAST)])
+    status = cookies.check_cookie_file(path)
+    assert not status.fresh
+    assert "expired" in status.reason
+
+
+def test_check_domain_filter(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(path, [(".cern.ch", "live", _FAR_FUTURE)])
+    status = cookies.check_cookie_file(path, domain="example.org")
+    assert not status.fresh
+    assert "no cookies" in status.reason
+
+
+def test_check_max_age(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(path, [(".cern.ch", "live", _FAR_FUTURE)])
+    old = (datetime.now(timezone.utc) - timedelta(hours=48)).timestamp()
+    os.utime(path, (old, old))
+    stale = cookies.check_cookie_file(path, max_age=timedelta(hours=12))
+    assert not stale.fresh
+    assert "older than max age" in stale.reason
+    assert cookies.check_cookie_file(path, max_age=timedelta(hours=72)).fresh
+
+
+def test_session_cookies_count_as_live(tmp_path):
+    path = tmp_path / "c.txt"
+    _write_cookie_file(path, [(".cern.ch", "session", "")])
+    status = cookies.check_cookie_file(path)
+    assert status.fresh
+    assert status.session_count == 1
+    assert status.earliest_expiry is None
+
+
+def test_looks_like_login_url():
+    assert cookies.looks_like_login_url(
+        "https://auth.cern.ch/auth/realms/cern"
+    )
+    assert cookies.looks_like_login_url("https://example.cern.ch/login")
+    assert cookies.looks_like_login_url("https://x.cern.ch/sso/redirect")
+    assert not cookies.looks_like_login_url(
+        "https://cms-conddb.cern.ch/cmsDbBrowser/"
+    )
+
+
+def test_looks_like_login_page():
+    assert cookies.looks_like_login_page("<title>Sign in to CERN</title>")
+    assert cookies.looks_like_login_page("redirecting to auth.cern.ch ...")
+    assert not cookies.looks_like_login_page("<h1>CondDB payloads</h1>")
+
+
+def test_acquisition_command_mentions_official_tool(tmp_path):
+    command = cookies.sso_cookie_acquisition_command(
+        "https://cms-conddb.cern.ch/", tmp_path / "conddb.txt"
+    )
+    assert command.startswith("auth-get-sso-cookie ")
+    assert "https://cms-conddb.cern.ch/" in command
+    assert "conddb.txt" in command

--- a/python/tests/auth/test_preflight.py
+++ b/python/tests/auth/test_preflight.py
@@ -1,0 +1,416 @@
+"""req.w2.auth — CERNPreflightSource probe evaluation, offline."""
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import requests
+
+from archi.auth import preflight as preflight_mod
+from archi.auth.preflight import CERNPreflightSource
+
+_FAR_FUTURE = int(datetime(2035, 1, 1, tzinfo=timezone.utc).timestamp())
+_PAST = int(datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp())
+
+
+def _write_cookie_file(path: Path, *, expires: int) -> None:
+    path.write_text(
+        "# Netscape HTTP Cookie File\n"
+        f".cern.ch\tTRUE\t/\tTRUE\t{expires}\tsessionid\ttest-value\n"
+    )
+
+
+def _write_cert(path: Path, *, not_after: datetime) -> None:
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "archi-preflight-test")]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_after - timedelta(days=30))
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, text="", url=""):
+        self.status_code = status_code
+        self.text = text
+        self.url = url
+
+
+def _fake_http(monkeypatch, *, response=None, exc=None):
+    calls = []
+
+    class _FakeSession:
+        def __init__(self):
+            self.cookies = requests.cookies.RequestsCookieJar()
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            if exc is not None:
+                raise exc
+            return response
+
+    monkeypatch.setattr(preflight_mod.requests, "Session", _FakeSession)
+    return calls
+
+
+def test_token_kind(monkeypatch):
+    source = CERNPreflightSource(
+        source_name="jira_token", kind="token", credential_ref="ARCHI_T_TOKEN"
+    )
+    monkeypatch.delenv("ARCHI_T_TOKEN", raising=False)
+    assert source.preflight().status == "missing_credential"
+    monkeypatch.setenv("ARCHI_T_TOKEN", "test-value")
+    result = source.preflight()
+    assert result.status == "ok"
+    assert result.credential_refs == ("ARCHI_T_TOKEN",)
+
+
+def test_file_kind(monkeypatch, tmp_path):
+    path = tmp_path / "ref.txt"
+    path.write_text("x")
+    source = CERNPreflightSource(
+        source_name="ref_file", kind="file", credential_ref="ARCHI_T_FILE"
+    )
+    monkeypatch.setenv("ARCHI_T_FILE", str(tmp_path / "absent.txt"))
+    assert source.preflight().status == "missing_credential"
+    monkeypatch.setenv("ARCHI_T_FILE", str(path))
+    assert source.preflight().status == "ok"
+
+
+def test_all_env_kind(monkeypatch):
+    source = CERNPreflightSource(
+        source_name="amq_env",
+        kind="all_env",
+        credential_refs=["ARCHI_T_AMQ_USER", "ARCHI_T_AMQ_PASSWORD"],
+    )
+    monkeypatch.setenv("ARCHI_T_AMQ_USER", "test-value")
+    monkeypatch.delenv("ARCHI_T_AMQ_PASSWORD", raising=False)
+    result = source.preflight()
+    assert result.status == "missing_credential"
+    assert "ARCHI_T_AMQ_PASSWORD" in result.reason
+    monkeypatch.setenv("ARCHI_T_AMQ_PASSWORD", "test-value")
+    assert source.preflight().status == "ok"
+
+
+def test_any_file_kind(monkeypatch, tmp_path):
+    path = tmp_path / "b.pem"
+    path.write_text("x")
+    source = CERNPreflightSource(
+        source_name="any_cred",
+        kind="any_file",
+        credential_refs=["ARCHI_T_A", "ARCHI_T_B"],
+    )
+    monkeypatch.delenv("ARCHI_T_A", raising=False)
+    monkeypatch.delenv("ARCHI_T_B", raising=False)
+    assert source.preflight().status == "missing_credential"
+    monkeypatch.setenv("ARCHI_T_B", str(path))
+    result = source.preflight()
+    assert result.status == "ok"
+    assert "ARCHI_T_B" in result.reason
+
+
+def test_ca_bundle_missing_is_tls_failed(monkeypatch):
+    source = CERNPreflightSource(
+        source_name="ca", kind="ca_bundle", credential_ref="ARCHI_T_CA"
+    )
+    monkeypatch.delenv("ARCHI_T_CA", raising=False)
+    result = source.preflight()
+    assert result.status == "tls_failed"
+    assert "refusing TLS bypass" in result.reason
+
+
+def test_cache_kind(tmp_path):
+    (tmp_path / "a.json").write_text(json.dumps([1, 2, 3]))
+    source = CERNPreflightSource(
+        source_name="cache",
+        kind="cache",
+        cache_paths=["a.json"],
+        base=str(tmp_path),
+    )
+    result = source.preflight()
+    assert result.status == "ok"
+    assert result.record_count == 3
+    missing = CERNPreflightSource(
+        source_name="cache",
+        kind="cache",
+        cache_paths=["absent.json"],
+        base=str(tmp_path),
+    )
+    assert missing.preflight().status == "cache_missing"
+
+
+def test_sso_cookie_kind(monkeypatch, tmp_path):
+    cookie_path = tmp_path / "sso.txt"
+    source = CERNPreflightSource(
+        source_name="sso",
+        kind="sso_cookie",
+        credential_ref="ARCHI_T_COOKIE",
+        max_age_hours=24,
+    )
+    monkeypatch.delenv("ARCHI_T_COOKIE", raising=False)
+    assert source.preflight().status == "missing_credential"
+    monkeypatch.setenv("ARCHI_T_COOKIE", str(cookie_path))
+    _write_cookie_file(cookie_path, expires=_FAR_FUTURE)
+    result = source.preflight()
+    assert result.status == "ok"
+    assert result.credential_refs == ("ARCHI_T_COOKIE",)
+    _write_cookie_file(cookie_path, expires=_PAST)
+    result = source.preflight()
+    assert result.status == "auth_failed"
+    assert "expired" in result.reason
+
+
+def test_x509_proxy_kind(monkeypatch, tmp_path):
+    proxy_path = tmp_path / "proxy.pem"
+    source = CERNPreflightSource(
+        source_name="proxy", kind="x509_proxy", credential_ref="ARCHI_T_PROXY"
+    )
+    monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
+    assert source.preflight().status == "missing_credential"
+    _write_cert(
+        proxy_path,
+        not_after=datetime.now(timezone.utc) + timedelta(hours=12),
+    )
+    result = source.preflight()
+    assert result.status == "ok"
+    assert "valid until" in result.reason
+    _write_cert(
+        proxy_path,
+        not_after=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    result = source.preflight()
+    assert result.status == "auth_failed"
+    assert "expired at" in result.reason
+
+
+def test_x509_proxy_unreadable_expiry_still_ok(monkeypatch, tmp_path):
+    proxy_path = tmp_path / "proxy.pem"
+    proxy_path.write_text("not a certificate")
+    source = CERNPreflightSource(
+        source_name="proxy", kind="x509_proxy", credential_ref="ARCHI_T_PROXY"
+    )
+    monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
+    result = source.preflight()
+    assert result.status == "ok"
+    assert "could not be read" in result.reason
+
+
+def test_cern_sso_http_authenticated(monkeypatch, tmp_path):
+    cookie_path = tmp_path / "sso.txt"
+    _write_cookie_file(cookie_path, expires=_FAR_FUTURE)
+    monkeypatch.setenv("ARCHI_T_COOKIE", str(cookie_path))
+    calls = _fake_http(
+        monkeypatch,
+        response=_FakeResponse(
+            200, "<h1>Protected docs</h1>", "https://docs.example.cern.ch/"
+        ),
+    )
+    source = CERNPreflightSource(
+        source_name="sso_http",
+        kind="cern_sso_http",
+        credential_ref="ARCHI_T_COOKIE",
+        endpoint="https://docs.example.cern.ch/",
+    )
+    result = source.preflight()
+    assert result.status == "ok"
+    assert result.credential_refs == ("ARCHI_T_COOKIE",)
+    assert calls and calls[0][0] == "https://docs.example.cern.ch/"
+
+
+def test_cern_sso_http_login_page_is_auth_failed(monkeypatch, tmp_path):
+    cookie_path = tmp_path / "sso.txt"
+    _write_cookie_file(cookie_path, expires=_FAR_FUTURE)
+    monkeypatch.setenv("ARCHI_T_COOKIE", str(cookie_path))
+    _fake_http(
+        monkeypatch,
+        response=_FakeResponse(
+            200,
+            "<title>Sign in to CERN</title>",
+            "https://auth.cern.ch/auth/realms/cern",
+        ),
+    )
+    source = CERNPreflightSource(
+        source_name="sso_http",
+        kind="cern_sso_http",
+        credential_ref="ARCHI_T_COOKIE",
+        endpoint="https://docs.example.cern.ch/",
+    )
+    assert source.preflight().status == "auth_failed"
+
+
+def test_cern_sso_http_error_statuses(monkeypatch, tmp_path):
+    cookie_path = tmp_path / "sso.txt"
+    _write_cookie_file(cookie_path, expires=_FAR_FUTURE)
+    monkeypatch.setenv("ARCHI_T_COOKIE", str(cookie_path))
+    source = CERNPreflightSource(
+        source_name="sso_http",
+        kind="cern_sso_http",
+        credential_ref="ARCHI_T_COOKIE",
+        endpoint="https://docs.example.cern.ch/",
+    )
+    _fake_http(
+        monkeypatch,
+        response=_FakeResponse(403, "", "https://docs.example.cern.ch/"),
+    )
+    assert source.preflight().status == "auth_failed"
+    _fake_http(monkeypatch, exc=requests.exceptions.SSLError("handshake"))
+    assert source.preflight().status == "tls_failed"
+    _fake_http(
+        monkeypatch, exc=requests.exceptions.ConnectionError("refused")
+    )
+    assert source.preflight().status == "endpoint_failed"
+
+
+def test_cern_tls_kind(monkeypatch, tmp_path):
+    ca_path = tmp_path / "ca.pem"
+    ca_path.write_text("test-bundle")
+    monkeypatch.setenv("ARCHI_T_CA", str(ca_path))
+    calls = _fake_http(
+        monkeypatch,
+        response=_FakeResponse(
+            200, "<h1>payloads</h1>", "https://svc.example.cern.ch/"
+        ),
+    )
+    source = CERNPreflightSource(
+        source_name="tls",
+        kind="cern_tls",
+        credential_ref="ARCHI_T_CA",
+        endpoint="https://svc.example.cern.ch/",
+    )
+    result = source.preflight()
+    assert result.status == "ok"
+    assert "CA bundle" in result.reason
+    assert calls[0][1]["verify"] == str(ca_path)
+
+
+def test_x509_http_expired_proxy_skips_network(monkeypatch, tmp_path):
+    proxy_path = tmp_path / "proxy.pem"
+    _write_cert(
+        proxy_path,
+        not_after=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
+    calls = _fake_http(monkeypatch, response=_FakeResponse(200))
+    source = CERNPreflightSource(
+        source_name="x509",
+        kind="x509_http",
+        credential_ref="ARCHI_T_PROXY",
+        endpoint="https://svc.example.cern.ch/",
+    )
+    result = source.preflight()
+    assert result.status == "auth_failed"
+    assert "expired at" in result.reason
+    assert calls == []
+
+
+def test_x509_http_valid_proxy(monkeypatch, tmp_path):
+    proxy_path = tmp_path / "proxy.pem"
+    _write_cert(
+        proxy_path,
+        not_after=datetime.now(timezone.utc) + timedelta(hours=12),
+    )
+    monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
+    calls = _fake_http(
+        monkeypatch,
+        response=_FakeResponse(200, "{}", "https://svc.example.cern.ch/"),
+    )
+    source = CERNPreflightSource(
+        source_name="x509",
+        kind="x509_http",
+        credential_ref="ARCHI_T_PROXY",
+        endpoint="https://svc.example.cern.ch/",
+    )
+    assert source.preflight().status == "ok"
+    assert calls[0][1]["cert"] == str(proxy_path)
+
+
+def test_x509_http_ssl_error_vocabulary(monkeypatch, tmp_path):
+    proxy_path = tmp_path / "proxy.pem"
+    _write_cert(
+        proxy_path,
+        not_after=datetime.now(timezone.utc) + timedelta(hours=12),
+    )
+    monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
+    source = CERNPreflightSource(
+        source_name="x509",
+        kind="x509_http",
+        credential_ref="ARCHI_T_PROXY",
+        endpoint="https://svc.example.cern.ch/",
+    )
+    _fake_http(
+        monkeypatch,
+        exc=requests.exceptions.SSLError("alert bad certificate"),
+    )
+    assert source.preflight().status == "auth_failed"
+    _fake_http(
+        monkeypatch,
+        exc=requests.exceptions.SSLError("unable to get issuer cert"),
+    )
+    assert source.preflight().status == "tls_failed"
+
+
+def test_https_kind(monkeypatch):
+    source = CERNPreflightSource(
+        source_name="reach",
+        kind="https",
+        endpoint="https://public.example.cern.ch/",
+    )
+    _fake_http(
+        monkeypatch,
+        response=_FakeResponse(
+            200, "<h1>ok</h1>", "https://public.example.cern.ch/"
+        ),
+    )
+    assert source.preflight().status == "ok"
+    _fake_http(
+        monkeypatch,
+        response=_FakeResponse(
+            200, "", "https://auth.cern.ch/auth/realms/cern"
+        ),
+    )
+    assert source.preflight().status == "auth_failed"
+    _fake_http(monkeypatch, response=_FakeResponse(500, "", ""))
+    assert source.preflight().status == "endpoint_failed"
+
+
+def test_unknown_kind_is_endpoint_failed():
+    source = CERNPreflightSource(source_name="odd", kind="bogus")
+    result = source.preflight()
+    assert result.status == "endpoint_failed"
+    assert "unknown preflight kind" in result.reason
+
+
+def test_missing_params_raise():
+    with pytest.raises(ValueError):
+        CERNPreflightSource(source_name="t", kind="token").preflight()
+    with pytest.raises(ValueError):
+        CERNPreflightSource(source_name="h", kind="https").preflight()
+
+
+def test_run_emits_no_facts(monkeypatch):
+    monkeypatch.setenv("ARCHI_T_TOKEN", "test-value")
+    source = CERNPreflightSource(
+        source_name="jira_token", kind="token", credential_ref="ARCHI_T_TOKEN"
+    )
+    run = source.run("run-1")
+    assert list(run.facts) == []
+    assert run.health is not None
+    assert run.health.status == "ok"
+
+
+def test_profile_is_live_overlay():
+    assert CERNPreflightSource.profile == "live_overlay"

--- a/python/tests/auth/test_preflight.py
+++ b/python/tests/auth/test_preflight.py
@@ -197,7 +197,9 @@ def test_x509_proxy_kind(monkeypatch, tmp_path):
     assert "expired at" in result.reason
 
 
-def test_x509_proxy_unreadable_expiry_still_ok(monkeypatch, tmp_path):
+def test_x509_proxy_undecodable_is_auth_failed(monkeypatch, tmp_path):
+    """An offline kind has no live-probe backstop, so an unreadable proxy
+    must not pass as healthy (code-review finding, 2026-08-11)."""
     proxy_path = tmp_path / "proxy.pem"
     proxy_path.write_text("not a certificate")
     source = CERNPreflightSource(
@@ -205,8 +207,27 @@ def test_x509_proxy_unreadable_expiry_still_ok(monkeypatch, tmp_path):
     )
     monkeypatch.setenv("ARCHI_T_PROXY", str(proxy_path))
     result = source.preflight()
-    assert result.status == "ok"
-    assert "could not be read" in result.reason
+    assert result.status == "auth_failed"
+    assert "could not be decoded" in result.reason
+
+
+def test_cern_sso_http_corrupt_cookie_is_auth_failed(monkeypatch, tmp_path):
+    """A cookie file that fails to parse is a credential problem, not an
+    endpoint problem — no request may be sent (code-review finding)."""
+    cookie_path = tmp_path / "sso.txt"
+    cookie_path.write_text("<html>this is not a cookie file</html>")
+    monkeypatch.setenv("ARCHI_T_COOKIE", str(cookie_path))
+    calls = _fake_http(monkeypatch, response=_FakeResponse(200, "x", "u"))
+    source = CERNPreflightSource(
+        source_name="sso_http",
+        kind="cern_sso_http",
+        credential_ref="ARCHI_T_COOKIE",
+        endpoint="https://docs.example.cern.ch/",
+    )
+    result = source.preflight()
+    assert result.status == "auth_failed"
+    assert "no request was sent" in result.reason
+    assert calls == []
 
 
 def test_cern_sso_http_authenticated(monkeypatch, tmp_path):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Import the working-tree package ahead of any installed archi."""
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -1,0 +1,80 @@
+"""req.w2.packaging — the v3 package coexists with the v2 build.
+
+Run with an okg-bearing interpreter (adapter modules import okg at
+module scope):
+
+    /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/ -v
+"""
+import re
+import subprocess
+import sys
+from importlib import resources
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_package_imports_and_version():
+    import archi
+
+    assert re.fullmatch(r"3\.\d+\.\d+(a|b|rc)?\d*", archi.__version__)
+
+
+def test_source_adapter_importable():
+    from archi.sources.cmssw import CMSSWReleaseSource
+
+    assert CMSSWReleaseSource.profile == "reference_catalog"
+    assert CMSSWReleaseSource.change_probe_kind == "content_hash"
+
+
+def test_schema_ships_in_package():
+    schema_files = [
+        p.name
+        for p in resources.files("archi.schemas").iterdir()
+        if p.name.endswith(".yaml")
+    ]
+    assert "operations_w1.yaml" in schema_files
+
+
+def test_v3_does_not_import_v2():
+    """python/archi must never import from the v2 tree (src/)."""
+    v3_files = list((REPO_ROOT / "python" / "archi").rglob("*.py"))
+    assert v3_files
+    for path in v3_files:
+        text = path.read_text(encoding="utf-8")
+        assert "from src." not in text and "import src." not in text, path
+
+
+def test_v2_build_files_untouched():
+    """The v2 build stays as archi_v3 has it: root pyproject/setup.py exist
+    and neither references python/ (the two builds share nothing)."""
+    root_pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    setup_py = REPO_ROOT / "setup.py"
+    assert setup_py.exists()
+    assert "python/" not in root_pyproject
+
+
+def test_no_operator_paths_in_package():
+    """req.w2.auth lint floor, applied from day one: no hardcoded
+    operator/host paths in package code."""
+    pattern = re.compile(r"[\"'](?:/Users/|/root/|/home/|/work/)")
+    for path in (REPO_ROOT / "python" / "archi").rglob("*.py"):
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            assert not pattern.search(line), f"{path}:{lineno}: {line.strip()}"
+
+
+def test_wheel_builds():
+    """The distribution builds from python/ without touching the root."""
+    result = subprocess.run(
+        [sys.executable, "-m", "hatchling", "build", "-t", "wheel",
+         "-d", str(REPO_ROOT / "python" / "dist")],
+        cwd=REPO_ROOT / "python",
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-800:]
+    wheels = list((REPO_ROOT / "python" / "dist").glob("archi-3.*.whl"))
+    assert wheels


### PR DESCRIPTION
**What this changes:** brings the already-reviewed W2 packaging (#603) and auth (#604) commits into `archi_v3`.

**Why needed:** the three stacked PRs merged in child-before-parent order this morning — #602 (w0→archi_v3) merged with an older head, so #603's and #604's commits landed only on the now-merged side branches, never on `archi_v3` (its tip 6502c107 has only W0 content). This PR completes the stack; the diff is exactly the #603+#604 content already reviewed.

**How I verified:** `git log origin/archi_v3` lacks the packaging/auth commits; `w2-auth` contains w0 ⊂ packaging ⊂ auth; python/tests 100/100 on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL